### PR TITLE
Fix file exclusion typo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ scholar:
 exclude:
   - Gemfile
   - Gemfile.lock
-  - update_boostrap.sh
+  - update_bootstrap.sh
   - switch_theme.sh
   - tags
   - Rakefile


### PR DESCRIPTION
## Summary
- correct the filename for the `update_bootstrap.sh` script in the Jekyll `exclude` list

## Testing
- `bundle install` *(fails: Forbidden – no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687f8882b1f48325a8aa35be09194328