### PR TITLE
Use absolute_url for stylesheet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
 
   <title>{% if page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{{ site.description }}">
-  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ "/assets/main.css" | absolute_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="shortcut icon" type ="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/favicon.ico">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">


### PR DESCRIPTION
## Summary
- load `main.css` using `absolute_url`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" due to disabled network)*

------
https://chatgpt.com/codex/tasks/task_e_6880667029588325a4fac47b477bdedc