### PR TITLE
Add affiliations to Systems Hall of Fame

### DIFF
--- a/_data/hof-authors.csv
+++ b/_data/hof-authors.csv
@@ -1,0 +1,2 @@
+name,affiliation
+M. Frans Kaashoek,Massachusetts Institute of Technology

--- a/_pages/sosp-osdi-hof.md
+++ b/_pages/sosp-osdi-hof.md
@@ -1,5 +1,5 @@
 ---
-title: "SOSP/OSDI Hall of Fame"
+title: "Systems Hall of Fame"
 layout: gridlay
 sitemap: false
 permalink: /sosp-osdi-hof/
@@ -12,10 +12,12 @@ This page lists authors with the most publications in SOSP and OSDI using data f
     <tr>
       <th>Rank</th>
       <th>Author</th>
+      <th>Affiliation</th>
       <th>Publications</th>
     </tr>
   </thead>
   <tbody>
+    {% assign author_info = site.data["hof-authors"] %}
     {% assign authors = site.data.hof | sort: 'freq' | reverse %}
     {% assign last_freq = '' %}
     {% assign rank = 0 %}
@@ -26,9 +28,17 @@ This page lists authors with the most publications in SOSP and OSDI using data f
         {% assign rank = index %}
         {% assign last_freq = author.freq %}
       {% endif %}
+        {% assign affiliation = "" %}
+        {% for info in author_info %}
+          {% if info.name == author.name %}
+            {% assign affiliation = info.affiliation %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
       <tr>
         <td>{{ rank }}</td>
         <td><a href="{{ author.dblp }}">{{ author.name }}</a></td>
+        <td>{{ affiliation }}</td>
         <td>{{ author.freq }}</td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- rename Hall of Fame page to **Systems Hall of Fame**
- add affiliation column and lookup affiliations from new data file
- add new `_data/hof-authors.csv` with last known affiliation

## Testing
- `bundle exec jekyll build` *(fails: bundler could not install due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68839c7b93e48325acdc775aa1397b6b