### PR TITLE
Update Hall of Fame ranking logic

### DIFF
--- a/_data/hof.csv
+++ b/_data/hof.csv
@@ -1,101 +1,101 @@
-name,affiliation,freq,dblp,orcid
-M. Frans Kaashoek,"MIT, Cambridge, USA",49,https://dblp.org/pid/k/MFransKaashoek,https://orcid.org/0000-0001-7098-586X
-Nickolai Zeldovich,"Massachusetts Institute of Technology, Cambridge, USA",39,https://dblp.org/pid/99/5780,
-Haibo Chen 0001,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems,China",31,https://dblp.org/pid/31/6601-1,https://orcid.org/0000-0002-9720-0361
-Ion Stoica,"University of California, Berkeley, USA",28,https://dblp.org/pid/s/IonStoica,https://orcid.org/0000-0002-5373-0088
-Gregory R. Ganger,"Carnegie Mellon University, Pittsburgh, USA",23,https://dblp.org/pid/g/GregoryRGanger,https://orcid.org/0000-0002-3065-7316
-Lidong Zhou,Microsoft Research,23,https://dblp.org/pid/z/LidongZhou,https://orcid.org/0000-0002-7258-3116
-Andrea C. Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,https://dblp.org/pid/a/AndreaCArpaciDusseau,https://orcid.org/0000-0001-8618-2738
-Remzi H. Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,https://dblp.org/pid/a/RemziHArpaciDusseau,https://orcid.org/0000-0001-9965-7704
-Henry M. Levy,"University of Washington, Seattle, Washington, USA",20,https://dblp.org/pid/l/HenryMLevy,https://orcid.org/0009-0008-7786-8541
-Jason Flinn,Facebook,20,https://dblp.org/pid/14/85,
-David Mazières,"Stanford University, Department of Computer Science, CA, USA",19,https://dblp.org/pid/m/DMazieres,https://orcid.org/0000-0002-1253-6449
-Fan Yang 0024,"Microsoft Research Asia, Beijing, China",18,https://dblp.org/pid/29/3081-24,https://orcid.org/0000-0002-0378-060X
-Ding Yuan 0004,"University of Toronto, Toronto, Canada",17,https://dblp.org/pid/230/9043-4,https://orcid.org/0000-0001-6322-0295
-Barbara Liskov,Massachusetts Institute of Technology,17,https://dblp.org/pid/l/BarbaraLiskov,
-Jason Nieh,"Columbia University, New York City, USA",17,https://dblp.org/pid/n/JasonNieh,https://orcid.org/0009-0005-8301-4479
-Shan Lu 0001,"Microsoft Research, Redmond, WA, USA",16,https://dblp.org/pid/31/5916-1,https://orcid.org/0000-0002-0757-4600
-Thomas E. Anderson,"University of Washington, Seattle, Washington, USA",16,https://dblp.org/pid/a/ThomasEAnderson,https://orcid.org/0009-0004-2951-0343
-Emmett Witchel,,15,https://dblp.org/pid/76/6082,https://orcid.org/0000-0002-1391-2880
-Junfeng Yang (disambiguation),,15,https://dblp.org/pid/71/3724,
-Amin Vahdat,Google,15,https://dblp.org/pid/v/AminVahdat,https://orcid.org/0000-0002-4866-1698
-Brian N. Bershad,"University of Washington, Seattle, Washington, USA",15,https://dblp.org/pid/b/BNBershad,
-Rong Chen 0001,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems, China",15,https://dblp.org/pid/22/6904-1,https://orcid.org/0000-0002-6115-8130
-Yuanyuan Zhou 0001,"University of California, San Diego, CA, USA",15,https://dblp.org/pid/99/2747-1,https://orcid.org/0000-0003-4760-7208
-Robert Morris 0005,"Massachusetts Institute of Technology (MIT), Cambridge, MA, USA",15,https://dblp.org/pid/82/11191,https://orcid.org/0009-0009-6885-0208
-Lorenzo Alvisi,"University of Texas at Austin, USA",15,https://dblp.org/pid/a/LAlvisi,https://orcid.org/0000-0002-9857-5528
-Taesoo Kim,,14,https://dblp.org/pid/38/8882,
-Arvind Krishnamurthy,"University of Washington, Seattle, Washington, USA",14,https://dblp.org/pid/k/AKrishnamurthy,
-Simon Peter 0001,"University of Washington, Seattle, WA, USA",14,https://dblp.org/pid/43/3917,https://orcid.org/0009-0007-4748-8524
-Jon Howell,,13,https://dblp.org/pid/55/3274,
-Sanidhya Kashyap,,13,https://dblp.org/pid/145/0912,
-Roger M. Needham,Microsoft Research,13,https://dblp.org/pid/n/RogerNeedham,
-Bryan Ford,"Swiss Federal Institute of Technology in Lausanne (EPFL), Switzerland",13,https://dblp.org/pid/f/BryanFord,https://orcid.org/0000-0002-0528-3033
-Miguel Castro 0001,"Microsoft Research, Cambridge, UK",13,https://dblp.org/pid/c/MiguelCastro,
-Larry L. Peterson,"Princeton University, USA",13,https://dblp.org/pid/p/LLPeterson,
-Scott Shenker,"University of California, Berkeley, USA",13,https://dblp.org/pid/34/5593,https://orcid.org/0000-0002-1357-7533
-Xi Wang 0005,"University of Washington, Seattle, WA, USA",13,https://dblp.org/pid/08/5760-5,
-Xin Jin 0008,"Peking University, China",13,https://dblp.org/pid/68/3340-8,https://orcid.org/0000-0001-8741-5847
-Peter Druschel,Max Planck Institute for Software Systems,13,https://dblp.org/pid/d/PDruschel,https://orcid.org/0000-0002-7239-1114
-Eddie Kohler,Harvard University,13,https://dblp.org/pid/78/5231,https://orcid.org/0000-0003-2027-0035
-Michael Dahlin,"University of Texas at Austin, USA",13,https://dblp.org/pid/d/MDahlin,
-Chunqiang Tang,,12,https://dblp.org/pid/81/4301,
-Kaushik Veeraraghavan,,12,https://dblp.org/pid/52/1896,
-Michael Stumm,,12,https://dblp.org/pid/82/5150,
-Manos Kapritsos,,12,https://dblp.org/pid/23/6695,https://orcid.org/0000-0002-4368-7418
-Wyatt Lloyd,,12,https://dblp.org/pid/21/1059,
-Matei Zaharia,"Stanford University, CA, USA",12,https://dblp.org/pid/36/2133,https://orcid.org/0000-0002-7547-7204
-Peng Huang 0005,"University of Michigan, Ann Arbor, USA",12,https://dblp.org/pid/29/1726-5,https://orcid.org/0000-0001-6315-0848
-Dawson R. Engler,"Stanford University, USA",12,https://dblp.org/pid/e/DREngler,
-Peter M. Chen,"University of Michigan, Ann Arbor, USA",12,https://dblp.org/pid/c/PeterMChen,
-Tianyin Xu,"University of Illinois at Urbana-Champaign, Department of Computer Science, Urbana, IL, USA",12,https://dblp.org/pid/90/7566,https://orcid.org/0000-0003-4443-8170
-Mao Yang 0004,"Microsoft Research, Beijing, China",12,https://dblp.org/pid/89/1482-4,https://orcid.org/HTTPS://ORCID.ORG/0009-0009-6455-3898
-Chris Hawblitzel,,11,https://dblp.org/pid/22/3053,
-Lingxiao Ma,,11,https://dblp.org/pid/57/3203,
-Tej Chajed,,11,https://dblp.org/pid/141/9176,
-George Candea,"Swiss Federal Institute of Technology in Lausanne, Switzerland",11,https://dblp.org/pid/c/GeorgeCandea,https://orcid.org/0009-0002-8107-6535
-Vijay Chidambaram,"University of Texas at Austin, Department of Computer Science, TX, USA",11,https://dblp.org/pid/07/10563,https://orcid.org/0000-0001-7985-6087
-Christoforos E. Kozyrakis,"Stanford University, USA",11,https://dblp.org/pid/k/ChristoforosEKozyrakis,https://orcid.org/0000-0002-3154-7530
-Marcos K. Aguilera,"VMware, Palo Alto, CA, USA",11,https://dblp.org/pid/10/553,https://orcid.org/0000-0003-3489-2468
-Guoqing Harry Xu,"University of California, Los Angeles, CA, USA",11,https://dblp.org/pid/90/8705,https://orcid.org/0000-0003-4737-2146
-David R. Cheriton,"Stanford University, USA",11,https://dblp.org/pid/c/DRCheriton,
-Baris Kasikci,,10,https://dblp.org/pid/31/11029,https://orcid.org/0000-0001-6122-8998
-Andreas Haeberlen,,10,https://dblp.org/pid/60/4358,https://orcid.org/0000-0002-3271-8354
-Kang Chen (disambiguation),,10,https://dblp.org/pid/91/6670,
-Irene Zhang,,10,https://dblp.org/pid/68/1122,
-Steve D. Gribble,"University of Washington, Seattle, Washington, USA",10,https://dblp.org/pid/g/StevenDGribble,https://orcid.org/0000-0002-2624-2142
-Sylvia Ratnasamy,"University of California, Berkeley, USA",10,https://dblp.org/pid/68/5579,
-Timothy Roscoe,"ETH Zurich, Switzerland",10,https://dblp.org/pid/r/TimothyRoscoe,https://orcid.org/0000-0002-8298-1126
-Ronghui Gu,"Columbia University, New York, NY, USA",10,https://dblp.org/pid/155/8148,
-Gerald J. Popek,"UCLA, Los Angeles, CA, USA",10,https://dblp.org/pid/62/6214,
-Changwoo Min,,9,https://dblp.org/pid/19/10203,
-Dan R. K. Ports,,9,https://dblp.org/pid/03/6105,https://orcid.org/0000-0001-6093-5711
-Jilong Xue,,9,https://dblp.org/pid/06/10336,
-Madan Musuvathi,Microsoft Research,9,https://dblp.org/pid/95/6578,
-John K. Ousterhout,"Stanford University, USA",9,https://dblp.org/pid/o/JohnKOusterhout,
-Ricardo Bianchini,"Microsoft Research, Redmond, WA, USA",9,https://dblp.org/pid/85/2722,https://orcid.org/0000-0001-5971-5084
-Haryadi S. Gunawi,University of Chicago,9,https://dblp.org/pid/84/5664,https://orcid.org/0000-0003-3680-8450
-Mahadev Satyanarayanan,"Carnegie Mellon University, Pittsburgh, USA",9,https://dblp.org/pid/s/MahadevSatyanarayanan,https://orcid.org/0000-0002-2187-2049
-Willy Zwaenepoel,"University of Sydney, NSW, Australia",9,https://dblp.org/pid/z/WZwaenepoel,https://orcid.org/0000-0002-4182-6920
-David K. Gifford,"MIT, Cambridge, USA",9,https://dblp.org/pid/g/DavidKGifford,https://orcid.org/0000-0003-1709-4034
-Rachit Agarwal 0001,"Cornell University, NY, USA",9,https://dblp.org/pid/41/5447-1,https://orcid.org/0000-0001-6731-9938
-Yang Wang 0009,"Ohio State University, Columbus, OH, USA",9,https://dblp.org/pid/w/YangWang9,https://orcid.org/0000-0002-9721-4923
-David G. Andersen,"Carnegie Mellon University, School of Computer Science, Pittsburgh, PA, USA",9,https://dblp.org/pid/a/DavidGAndersen,
-Adam Belay,,8,https://dblp.org/pid/14/8279,
-Asaf Cidon,,8,https://dblp.org/pid/35/10805,https://orcid.org/0009-0007-4046-2022
-Bryan Parno,,8,https://dblp.org/pid/49/6324,
-Michael Kaminsky,,8,https://dblp.org/pid/09/4259,
-Kirk Rodrigues,,8,https://dblp.org/pid/188/9963,
-K. V. Rashmi,,8,https://dblp.org/pid/40/7113,https://orcid.org/0000-0002-2227-7460
-Sebastian Angel,,8,https://dblp.org/pid/132/8480,
-Ramnatthan Alagappan,,8,https://dblp.org/pid/154/0847,https://orcid.org/0000-0001-9911-4208
-Srinath T. V. Setty,,8,https://dblp.org/pid/68/8463,
-Jacob R. Lorch,"Microsoft Research, Redmond, WA, USA",8,https://dblp.org/pid/25/3228,https://orcid.org/0000-0002-7269-2769
-Michael D. Schroeder,Microsoft Research Silicon Valley,8,https://dblp.org/pid/s/MichaelDSchroeder,
-Joseph Gonzalez 0001,"University of California at Berkeley, CA, USA",8,https://dblp.org/pid/61/8262,https://orcid.org/0000-0003-2921-956X
-Jay Lepreau,"University of Utah, Salt Lake City, Utah, USA",8,https://dblp.org/pid/l/JayLepreau,
-Raluca A. Popa,"University of California, Berkeley, CA, USA",8,https://dblp.org/pid/91/275,https://orcid.org/0000-0001-8899-801X
-Mosharaf Chowdhury,"University of Michigan, USA",8,https://dblp.org/pid/42/1518,https://orcid.org/0000-0003-0884-6740
-Michael Walfish,"New York University, Courant Institute of Mathematical Sciences, NY, USA",8,https://dblp.org/pid/00/2879,
-Emin Gün Sirer,"Cornell University, Ithaca, USA",8,https://dblp.org/pid/s/EminGunSirer,
-Kai Li 0001,"Princeton University, NJ, USA",8,https://dblp.org/pid/l/KaiLi1,https://orcid.org/0000-0002-2095-7024
+name,last,affiliation,freq,dblp,orcid
+M. Frans Kaashoek,Kaashoek,"MIT, Cambridge, USA",49,https://dblp.org/pid/k/MFransKaashoek,https://orcid.org/0000-0001-7098-586X
+Nickolai Zeldovich,Zeldovich,"Massachusetts Institute of Technology, Cambridge, USA",39,https://dblp.org/pid/99/5780,
+Haibo Chen 0001,Chen,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems,China",31,https://dblp.org/pid/31/6601-1,https://orcid.org/0000-0002-9720-0361
+Ion Stoica,Stoica,"University of California, Berkeley, USA",28,https://dblp.org/pid/s/IonStoica,https://orcid.org/0000-0002-5373-0088
+Gregory R. Ganger,Ganger,"Carnegie Mellon University, Pittsburgh, USA",23,https://dblp.org/pid/g/GregoryRGanger,https://orcid.org/0000-0002-3065-7316
+Lidong Zhou,Zhou,Microsoft Research,23,https://dblp.org/pid/z/LidongZhou,https://orcid.org/0000-0002-7258-3116
+Andrea C. Arpaci-Dusseau,Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,https://dblp.org/pid/a/AndreaCArpaciDusseau,https://orcid.org/0000-0001-8618-2738
+Remzi H. Arpaci-Dusseau,Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,https://dblp.org/pid/a/RemziHArpaciDusseau,https://orcid.org/0000-0001-9965-7704
+Henry M. Levy,Levy,"University of Washington, Seattle, Washington, USA",20,https://dblp.org/pid/l/HenryMLevy,https://orcid.org/0009-0008-7786-8541
+Jason Flinn,Flinn,Facebook,20,https://dblp.org/pid/14/85,
+David Mazières,Mazières,"Stanford University, Department of Computer Science, CA, USA",19,https://dblp.org/pid/m/DMazieres,https://orcid.org/0000-0002-1253-6449
+Fan Yang 0024,Yang,"Microsoft Research Asia, Beijing, China",18,https://dblp.org/pid/29/3081-24,https://orcid.org/0000-0002-0378-060X
+Ding Yuan 0004,Yuan,"University of Toronto, Toronto, Canada",17,https://dblp.org/pid/230/9043-4,https://orcid.org/0000-0001-6322-0295
+Barbara Liskov,Liskov,Massachusetts Institute of Technology,17,https://dblp.org/pid/l/BarbaraLiskov,
+Jason Nieh,Nieh,"Columbia University, New York City, USA",17,https://dblp.org/pid/n/JasonNieh,https://orcid.org/0009-0005-8301-4479
+Shan Lu 0001,Lu,"Microsoft Research, Redmond, WA, USA",16,https://dblp.org/pid/31/5916-1,https://orcid.org/0000-0002-0757-4600
+Thomas E. Anderson,Anderson,"University of Washington, Seattle, Washington, USA",16,https://dblp.org/pid/a/ThomasEAnderson,https://orcid.org/0009-0004-2951-0343
+Emmett Witchel,Witchel,,15,https://dblp.org/pid/76/6082,https://orcid.org/0000-0002-1391-2880
+Junfeng Yang (disambiguation),Yang,,15,https://dblp.org/pid/71/3724,
+Amin Vahdat,Vahdat,Google,15,https://dblp.org/pid/v/AminVahdat,https://orcid.org/0000-0002-4866-1698
+Brian N. Bershad,Bershad,"University of Washington, Seattle, Washington, USA",15,https://dblp.org/pid/b/BNBershad,
+Rong Chen 0001,Chen,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems, China",15,https://dblp.org/pid/22/6904-1,https://orcid.org/0000-0002-6115-8130
+Yuanyuan Zhou 0001,Zhou,"University of California, San Diego, CA, USA",15,https://dblp.org/pid/99/2747-1,https://orcid.org/0000-0003-4760-7208
+Robert Morris 0005,Morris,"Massachusetts Institute of Technology (MIT), Cambridge, MA, USA",15,https://dblp.org/pid/82/11191,https://orcid.org/0009-0009-6885-0208
+Lorenzo Alvisi,Alvisi,"University of Texas at Austin, USA",15,https://dblp.org/pid/a/LAlvisi,https://orcid.org/0000-0002-9857-5528
+Taesoo Kim,Kim,,14,https://dblp.org/pid/38/8882,
+Arvind Krishnamurthy,Krishnamurthy,"University of Washington, Seattle, Washington, USA",14,https://dblp.org/pid/k/AKrishnamurthy,
+Simon Peter 0001,Peter,"University of Washington, Seattle, WA, USA",14,https://dblp.org/pid/43/3917,https://orcid.org/0009-0007-4748-8524
+Jon Howell,Howell,,13,https://dblp.org/pid/55/3274,
+Sanidhya Kashyap,Kashyap,,13,https://dblp.org/pid/145/0912,
+Roger M. Needham,Needham,Microsoft Research,13,https://dblp.org/pid/n/RogerNeedham,
+Bryan Ford,Ford,"Swiss Federal Institute of Technology in Lausanne (EPFL), Switzerland",13,https://dblp.org/pid/f/BryanFord,https://orcid.org/0000-0002-0528-3033
+Miguel Castro 0001,Castro,"Microsoft Research, Cambridge, UK",13,https://dblp.org/pid/c/MiguelCastro,
+Larry L. Peterson,Peterson,"Princeton University, USA",13,https://dblp.org/pid/p/LLPeterson,
+Scott Shenker,Shenker,"University of California, Berkeley, USA",13,https://dblp.org/pid/34/5593,https://orcid.org/0000-0002-1357-7533
+Xi Wang 0005,Wang,"University of Washington, Seattle, WA, USA",13,https://dblp.org/pid/08/5760-5,
+Xin Jin 0008,Jin,"Peking University, China",13,https://dblp.org/pid/68/3340-8,https://orcid.org/0000-0001-8741-5847
+Peter Druschel,Druschel,Max Planck Institute for Software Systems,13,https://dblp.org/pid/d/PDruschel,https://orcid.org/0000-0002-7239-1114
+Eddie Kohler,Kohler,Harvard University,13,https://dblp.org/pid/78/5231,https://orcid.org/0000-0003-2027-0035
+Michael Dahlin,Dahlin,"University of Texas at Austin, USA",13,https://dblp.org/pid/d/MDahlin,
+Chunqiang Tang,Tang,,12,https://dblp.org/pid/81/4301,
+Kaushik Veeraraghavan,Veeraraghavan,,12,https://dblp.org/pid/52/1896,
+Michael Stumm,Stumm,,12,https://dblp.org/pid/82/5150,
+Manos Kapritsos,Kapritsos,,12,https://dblp.org/pid/23/6695,https://orcid.org/0000-0002-4368-7418
+Wyatt Lloyd,Lloyd,,12,https://dblp.org/pid/21/1059,
+Matei Zaharia,Zaharia,"Stanford University, CA, USA",12,https://dblp.org/pid/36/2133,https://orcid.org/0000-0002-7547-7204
+Peng Huang 0005,Huang,"University of Michigan, Ann Arbor, USA",12,https://dblp.org/pid/29/1726-5,https://orcid.org/0000-0001-6315-0848
+Dawson R. Engler,Engler,"Stanford University, USA",12,https://dblp.org/pid/e/DREngler,
+Peter M. Chen,Chen,"University of Michigan, Ann Arbor, USA",12,https://dblp.org/pid/c/PeterMChen,
+Tianyin Xu,Xu,"University of Illinois at Urbana-Champaign, Department of Computer Science, Urbana, IL, USA",12,https://dblp.org/pid/90/7566,https://orcid.org/0000-0003-4443-8170
+Mao Yang 0004,Yang,"Microsoft Research, Beijing, China",12,https://dblp.org/pid/89/1482-4,https://orcid.org/HTTPS://ORCID.ORG/0009-0009-6455-3898
+Chris Hawblitzel,Hawblitzel,,11,https://dblp.org/pid/22/3053,
+Lingxiao Ma,Ma,,11,https://dblp.org/pid/57/3203,
+Tej Chajed,Chajed,,11,https://dblp.org/pid/141/9176,
+George Candea,Candea,"Swiss Federal Institute of Technology in Lausanne, Switzerland",11,https://dblp.org/pid/c/GeorgeCandea,https://orcid.org/0009-0002-8107-6535
+Vijay Chidambaram,Chidambaram,"University of Texas at Austin, Department of Computer Science, TX, USA",11,https://dblp.org/pid/07/10563,https://orcid.org/0000-0001-7985-6087
+Christoforos E. Kozyrakis,Kozyrakis,"Stanford University, USA",11,https://dblp.org/pid/k/ChristoforosEKozyrakis,https://orcid.org/0000-0002-3154-7530
+Marcos K. Aguilera,Aguilera,"VMware, Palo Alto, CA, USA",11,https://dblp.org/pid/10/553,https://orcid.org/0000-0003-3489-2468
+Guoqing Harry Xu,Xu,"University of California, Los Angeles, CA, USA",11,https://dblp.org/pid/90/8705,https://orcid.org/0000-0003-4737-2146
+David R. Cheriton,Cheriton,"Stanford University, USA",11,https://dblp.org/pid/c/DRCheriton,
+Baris Kasikci,Kasikci,,10,https://dblp.org/pid/31/11029,https://orcid.org/0000-0001-6122-8998
+Andreas Haeberlen,Haeberlen,,10,https://dblp.org/pid/60/4358,https://orcid.org/0000-0002-3271-8354
+Kang Chen (disambiguation),Chen,,10,https://dblp.org/pid/91/6670,
+Irene Zhang,Zhang,,10,https://dblp.org/pid/68/1122,
+Steve D. Gribble,Gribble,"University of Washington, Seattle, Washington, USA",10,https://dblp.org/pid/g/StevenDGribble,https://orcid.org/0000-0002-2624-2142
+Sylvia Ratnasamy,Ratnasamy,"University of California, Berkeley, USA",10,https://dblp.org/pid/68/5579,
+Timothy Roscoe,Roscoe,"ETH Zurich, Switzerland",10,https://dblp.org/pid/r/TimothyRoscoe,https://orcid.org/0000-0002-8298-1126
+Ronghui Gu,Gu,"Columbia University, New York, NY, USA",10,https://dblp.org/pid/155/8148,
+Gerald J. Popek,Popek,"UCLA, Los Angeles, CA, USA",10,https://dblp.org/pid/62/6214,
+Changwoo Min,Min,,9,https://dblp.org/pid/19/10203,
+Dan R. K. Ports,Ports,,9,https://dblp.org/pid/03/6105,https://orcid.org/0000-0001-6093-5711
+Jilong Xue,Xue,,9,https://dblp.org/pid/06/10336,
+Madan Musuvathi,Musuvathi,Microsoft Research,9,https://dblp.org/pid/95/6578,
+John K. Ousterhout,Ousterhout,"Stanford University, USA",9,https://dblp.org/pid/o/JohnKOusterhout,
+Ricardo Bianchini,Bianchini,"Microsoft Research, Redmond, WA, USA",9,https://dblp.org/pid/85/2722,https://orcid.org/0000-0001-5971-5084
+Haryadi S. Gunawi,Gunawi,University of Chicago,9,https://dblp.org/pid/84/5664,https://orcid.org/0000-0003-3680-8450
+Mahadev Satyanarayanan,Satyanarayanan,"Carnegie Mellon University, Pittsburgh, USA",9,https://dblp.org/pid/s/MahadevSatyanarayanan,https://orcid.org/0000-0002-2187-2049
+Willy Zwaenepoel,Zwaenepoel,"University of Sydney, NSW, Australia",9,https://dblp.org/pid/z/WZwaenepoel,https://orcid.org/0000-0002-4182-6920
+David K. Gifford,Gifford,"MIT, Cambridge, USA",9,https://dblp.org/pid/g/DavidKGifford,https://orcid.org/0000-0003-1709-4034
+Rachit Agarwal 0001,Agarwal,"Cornell University, NY, USA",9,https://dblp.org/pid/41/5447-1,https://orcid.org/0000-0001-6731-9938
+Yang Wang 0009,Wang,"Ohio State University, Columbus, OH, USA",9,https://dblp.org/pid/w/YangWang9,https://orcid.org/0000-0002-9721-4923
+David G. Andersen,Andersen,"Carnegie Mellon University, School of Computer Science, Pittsburgh, PA, USA",9,https://dblp.org/pid/a/DavidGAndersen,
+Adam Belay,Belay,,8,https://dblp.org/pid/14/8279,
+Asaf Cidon,Cidon,,8,https://dblp.org/pid/35/10805,https://orcid.org/0009-0007-4046-2022
+Bryan Parno,Parno,,8,https://dblp.org/pid/49/6324,
+Michael Kaminsky,Kaminsky,,8,https://dblp.org/pid/09/4259,
+Kirk Rodrigues,Rodrigues,,8,https://dblp.org/pid/188/9963,
+K. V. Rashmi,Rashmi,,8,https://dblp.org/pid/40/7113,https://orcid.org/0000-0002-2227-7460
+Sebastian Angel,Angel,,8,https://dblp.org/pid/132/8480,
+Ramnatthan Alagappan,Alagappan,,8,https://dblp.org/pid/154/0847,https://orcid.org/0000-0001-9911-4208
+Srinath T. V. Setty,Setty,,8,https://dblp.org/pid/68/8463,
+Jacob R. Lorch,Lorch,"Microsoft Research, Redmond, WA, USA",8,https://dblp.org/pid/25/3228,https://orcid.org/0000-0002-7269-2769
+Michael D. Schroeder,Schroeder,Microsoft Research Silicon Valley,8,https://dblp.org/pid/s/MichaelDSchroeder,
+Joseph Gonzalez 0001,Gonzalez,"University of California at Berkeley, CA, USA",8,https://dblp.org/pid/61/8262,https://orcid.org/0000-0003-2921-956X
+Jay Lepreau,Lepreau,"University of Utah, Salt Lake City, Utah, USA",8,https://dblp.org/pid/l/JayLepreau,
+Raluca A. Popa,Popa,"University of California, Berkeley, CA, USA",8,https://dblp.org/pid/91/275,https://orcid.org/0000-0001-8899-801X
+Mosharaf Chowdhury,Chowdhury,"University of Michigan, USA",8,https://dblp.org/pid/42/1518,https://orcid.org/0000-0003-0884-6740
+Michael Walfish,Walfish,"New York University, Courant Institute of Mathematical Sciences, NY, USA",8,https://dblp.org/pid/00/2879,
+Emin Gün Sirer,Sirer,"Cornell University, Ithaca, USA",8,https://dblp.org/pid/s/EminGunSirer,
+Kai Li 0001,Li,"Princeton University, NJ, USA",8,https://dblp.org/pid/l/KaiLi1,https://orcid.org/0000-0002-2095-7024

--- a/_pages/sosp-osdi-hof.md
+++ b/_pages/sosp-osdi-hof.md
@@ -7,9 +7,9 @@ permalink: /sosp-osdi-hof/
 
 ### Systems Research: SOSP/OSDI Hall of Fame
 
-Authors are ranked by total number of SOSP and OSDI papers (the top conferences for systems research). Authors with same number of papers have the same rank.
+Authors are ranked by total number of SOSP and OSDI papers (the top conferences for systems research). Several authors can share the same rank and the next rank is incremented by one.
 
-For display purposes, within each rank, authors are sorted by last name. Top 100 (approximately) authors are shown.
+For display purposes, authors sharing the same rank are sorted by last name. Top 100 (approximately) authors are shown.
 
 Disclaimers: A real Hall of Fame should be determined by impact, not paper count.
 Data pulled from [DBLP](https://dblp.org) using SPARQL.
@@ -34,16 +34,12 @@ Reflects data up-to OSDI 25.
   </thead>
   <tbody>
     {% assign author_info = site.data["hof-authors"] %}
-    {% assign authors = site.data.hof | sort: 'freq' | reverse %}
-    {% assign last_freq = '' %}
+    {% assign authors_by_name = site.data.hof | sort: 'last' %}
+    {% assign groups = authors_by_name | group_by: 'freq' | sort: 'name' | reverse %}
     {% assign rank = 0 %}
-    {% assign index = 0 %}
-    {% for author in authors %}
-      {% assign index = index | plus: 1 %}
-      {% if author.freq != last_freq %}
-        {% assign rank = index %}
-        {% assign last_freq = author.freq %}
-      {% endif %}
+    {% for group in groups %}
+      {% assign rank = rank | plus: 1 %}
+      {% for author in group.items %}
         {% assign affiliation = "" %}
         {% for info in author_info %}
           {% if info.name == author.name %}
@@ -51,12 +47,13 @@ Reflects data up-to OSDI 25.
             {% break %}
           {% endif %}
         {% endfor %}
-      <tr>
-        <td>{{ rank }}</td>
-        <td><a href="{{ author.dblp }}">{{ author.name }}</a></td>
-        <td>{{ affiliation }}</td>
-        <td>{{ author.freq }}</td>
-      </tr>
+        <tr>
+          <td>{{ rank }}</td>
+          <td><a href="{{ author.dblp }}">{{ author.name }}</a></td>
+          <td>{{ affiliation }}</td>
+          <td>{{ author.freq }}</td>
+        </tr>
+      {% endfor %}
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- adjust description for ranking policy
- support dense ranking and sort ties by last name
- add last-name field to Hall of Fame data

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688432f7bcf08325af50b4d88de85487