### PR TITLE
Add slides/video/audio buttons to publications

### DIFF
--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -56,10 +56,10 @@ pre{
 <a href="{{ entry.slides }}" target="_blank"><button class="btn btn-info btm-sm">SLIDES</button></a>
 {% endif %}
 {% if entry.video %}
-<a href="{{ entry.video }}" target="_blank"><button class="btn btn-dark btm-sm">VIDEO</button></a>
+<a href="{{ entry.video }}" target="_blank"><button class="btn btn-media btm-sm">VIDEO</button></a>
 {% endif %}
 {% if entry.audio %}
-<a href="{{ entry.audio }}" target="_blank"><button class="btn btn-secondary btm-sm">AUDIO</button></a>
+<a href="{{ entry.audio }}" target="_blank"><button class="btn btn-media btm-sm">AUDIO</button></a>
 {% endif %}
 
 {% if entry.type == 'unpublished' or entry.type == 'article' or  entry.type == 'thesis' or entry.type == 'inproceedings' or entry.type == 'report' %}

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -52,6 +52,16 @@ pre{
 {% endif %}
 {% endif %}
 
+{% if entry.slides %}
+<a href="{{ entry.slides }}" target="_blank"><button class="btn btn-info btm-sm">SLIDES</button></a>
+{% endif %}
+{% if entry.video %}
+<a href="{{ entry.video }}" target="_blank"><button class="btn btn-dark btm-sm">VIDEO</button></a>
+{% endif %}
+{% if entry.audio %}
+<a href="{{ entry.audio }}" target="_blank"><button class="btn btn-secondary btm-sm">AUDIO</button></a>
+{% endif %}
+
 {% if entry.type == 'unpublished' or entry.type == 'article' or  entry.type == 'thesis' or entry.type == 'inproceedings' or entry.type == 'report' %}
 <button class="btn btn-danger btm-sm"  onclick="toggleBibtex('{{entry.key}}')">BIB</button>
 {% endif %}

--- a/_sass/SHB_css.scss
+++ b/_sass/SHB_css.scss
@@ -19,6 +19,30 @@ img {
     margin-bottom: 5px;
 }
 
+/* Purple media buttons for audio and video links */
+.btn-media {
+    color: #fff;
+    background-color: #6f42c1;
+    border-color: #6f42c1;
+}
+
+.btn-media:hover,
+.btn-media:focus,
+.btn-media:active,
+.btn-media.active,
+.show > .btn-media.dropdown-toggle {
+    color: #fff;
+    background-color: darken(#6f42c1, 7.5%);
+    border-color: darken(#6f42c1, 10%);
+}
+
+.btn-media:disabled,
+.btn-media.disabled {
+    color: #fff;
+    background-color: #6f42c1;
+    border-color: #6f42c1;
+}
+
 .container-fluid {
   max-width: 800px;
 }


### PR DESCRIPTION
## Summary
- Show Slides button when a `slides` field is present in ref.bib entries
- Include Video and Audio buttons that link to corresponding media

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_688e4921603c8325beb062366562f728