### PR TITLE
Fix collapsed details for publications by year

### DIFF
--- a/_pages/publications-by-year.html
+++ b/_pages/publications-by-year.html
@@ -6,15 +6,6 @@ permalink: /publications-by-year/
 years: [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
 ---
 
-<style>
-summary.year-heading {
-  font-size: 1.25rem;
-  font-weight: bold;
-  cursor: pointer;
-  margin-top: 1rem;
-}
-</style>
-
 {% for y in page.years %}
 <details class="year-details">
   <summary class="year-heading">{{ y }}</summary>
@@ -23,11 +14,4 @@ summary.year-heading {
   </div>
 </details>
 {% endfor %}
-
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-  document.querySelectorAll('.year-details').forEach(function (el) {
-    el.removeAttribute('open');
-  });
-});
-</script>
+<script src="{{ '/assets/javascript/publications-by-year.js' | relative_url }}"></script>

--- a/_pages/publications-by-year.md
+++ b/_pages/publications-by-year.md
@@ -6,6 +6,7 @@ permalink: /publications-by-year/
 years: [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
 ---
 
+<div markdown="0">
 {% for y in page.years %}
 <details class="year-details">
   <summary class="year-heading">{{ y }}</summary>
@@ -15,3 +16,4 @@ years: [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
 </details>
 {% endfor %}
 <script src="{{ '/assets/javascript/publications-by-year.js' | relative_url }}"></script>
+</div>

--- a/_pages/publications-by-year.md
+++ b/_pages/publications-by-year.md
@@ -16,8 +16,18 @@ summary.year-heading {
 </style>
 
 {% for y in page.years %}
-<details>
+<details class="year-details">
   <summary class="year-heading">{{ y }}</summary>
-  {% bibliography --query @*[year={{ y }}] %}
+  <div class="year-list">
+    {% bibliography --query @*[year={{ y }}] %}
+  </div>
 </details>
 {% endfor %}
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.year-details').forEach(function (el) {
+    el.removeAttribute('open');
+  });
+});
+</script>

--- a/assets/javascript/publications-by-year.js
+++ b/assets/javascript/publications-by-year.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.year-details').forEach(el => {
+    el.removeAttribute('open');
+  });
+});

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -11,3 +11,11 @@ $baseurl: "{{ site.url }}{{ site.baseurl }}";
 // @import "bootstrap_customization";
 @import "bootstrap";
 @import "SHB_css";
+
+summary.year-heading {
+  font-size: 1.25rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- Ensure publications-by-year lists are wrapped correctly to avoid stray closing tags
- Add script to collapse year sections on load

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_688eb1d664588325a9f2359823f310af