### PR TITLE
Style publication entries with bold titles and full author names

### DIFF
--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -24,13 +24,14 @@ pre{
 
 
 <div class="text-justify">
-  <strong>{{ entry.title | unescape_tilde }}</strong><br/>
-  {% if entry.author %}
-    {% for author in entry.author %}
+  <strong>{{ entry.title | unescape_tilde }}</strong>
+  {% if entry.author_array %}
+    <br/>
+    {% for author in entry.author_array %}
       {{ author.first }} {{ author.last }}{% unless forloop.last %}, {% endunless %}
     {% endfor %}
-    <br/>
   {% endif %}
+  <br/>
   {% if entry.booktitle %}
     <em>{{ entry.booktitle | unescape_tilde }}</em>
   {% elsif entry.journal %}

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -27,8 +27,9 @@ pre{
   <strong>{{ entry.title | unescape_tilde }}</strong><br/>
   {% if entry.author %}
     {% for author in entry.author %}
-      {{ author.first }} {{ author.last }}{% unless forloop.last %}, {% endunless %}
-    {% endfor %}<br/>
+      {{ author.first | join: ' ' }} {{ author.last | join: ' ' }}{% unless forloop.last %}, {% endunless %}
+    {% endfor %}
+    <br/>
   {% endif %}
   {% if entry.booktitle %}
     <em>{{ entry.booktitle | unescape_tilde }}</em>

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -27,7 +27,7 @@ pre{
   <strong>{{ entry.title | unescape_tilde }}</strong><br/>
   {% if entry.author %}
     {% for author in entry.author %}
-      {{ author.first | join: ' ' }} {{ author.last | join: ' ' }}{% unless forloop.last %}, {% endunless %}
+      {{ author.first }} {{ author.last }}{% unless forloop.last %}, {% endunless %}
     {% endfor %}
     <br/>
   {% endif %}

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -33,11 +33,11 @@ pre{
   {% endif %}
   <br/>
   {% if entry.booktitle %}
-    <em>{{ entry.booktitle | unescape_tilde }}</em>
+    <em>{{ entry.booktitle | remove: '"' | unescape_tilde }}</em>
   {% elsif entry.journal %}
-    <em>{{ entry.journal | unescape_tilde }}</em>
+    <em>{{ entry.journal | remove: '"' | unescape_tilde }}{% if entry.volume %}, Volume {{ entry.volume }}{% endif %}{% if entry.number %}, Issue {{ entry.number }}{% endif %}</em>
   {% elsif entry.publisher %}
-    <em>{{ entry.publisher | unescape_tilde }}</em>
+    <em>{{ entry.publisher | remove: '"' | unescape_tilde }}</em>
   {% endif %}
 </div>
 

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -23,7 +23,21 @@ pre{
 </style>
 
 
-<div class="text-justify">{{ reference | unescape_tilde }}</div>
+<div class="text-justify">
+  <strong>{{ entry.title | unescape_tilde }}</strong><br/>
+  {% if entry.author %}
+    {% for author in entry.author %}
+      {{ author.first }} {{ author.last }}{% unless forloop.last %}, {% endunless %}
+    {% endfor %}<br/>
+  {% endif %}
+  {% if entry.booktitle %}
+    <em>{{ entry.booktitle | unescape_tilde }}</em>
+  {% elsif entry.journal %}
+    <em>{{ entry.journal | unescape_tilde }}</em>
+  {% elsif entry.publisher %}
+    <em>{{ entry.publisher | unescape_tilde }}</em>
+  {% endif %}
+</div>
 
 <!-- You can use the below to make your name bold -->
 <!-- {{reference | replace_first: 'Bryngelson, S. H.', '<b>Bryngelson, S. H.</b>' | replace_first: 'Bryngelson, S.', '<b>Bryngelson, S.</b>' }}</div> -->

--- a/_pages/full-publications.md
+++ b/_pages/full-publications.md
@@ -17,20 +17,20 @@ years: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 
 <div class="jumbotron">
 ### Preprints
-{% bibliography --query @unpublished %}
+{% bibliography --template bibtemplate --query @unpublished %}
 </div>
 
 <div class="jumbotron">
 ### Refereed conference proceedings
-{% bibliography --query @inproceedings[group!=workshop] %}
+{% bibliography --template bibtemplate --query @inproceedings[group!=workshop] %}
 </div>
 
 <div class="jumbotron">
 ### Refereed journal articles
-{% bibliography --query @article %}
+{% bibliography --template bibtemplate --query @article %}
 </div>
 
 <div class="jumbotron">
 ### Workshop papers
-{% bibliography --query @*[group=workshop] %}
+{% bibliography --template bibtemplate --query @*[group=workshop] %}
 </div>

--- a/_pages/publications-by-year.md
+++ b/_pages/publications-by-year.md
@@ -11,7 +11,7 @@ years: [2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
 <details class="year-details">
   <summary class="year-heading">{{ y }}</summary>
   <div class="year-list">
-    {% bibliography --query @*[year={{ y }}] %}
+    {% bibliography --template bibtemplate --query @*[year={{ y }}] %}
   </div>
 </details>
 {% endfor %}


### PR DESCRIPTION
## Summary
- render publications with bold titles, full author names, italic venues and action buttons
- ensure full and yearly publication pages use new bibliography template

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688f920779e88325a95145bcc985cd2b