### PR TITLE
Add institution summary table to Hall of Fame

### DIFF
--- a/_pages/hall-of-fame.md
+++ b/_pages/hall-of-fame.md
@@ -61,3 +61,25 @@ Reflects data up-to OSDI 25.
   </tbody>
 </table>
 
+### Top Institutions
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Institution</th>
+      <th>Authors</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% assign author_info = site.data["hof-authors"] %}
+    {% assign affiliation_groups = author_info | where_exp: "item", "item.affiliation != ''" | group_by: "affiliation" | sort: "size" | reverse %}
+    {% assign top_affiliations = affiliation_groups | slice: 0, 10 %}
+    {% for group in top_affiliations %}
+      <tr>
+        <td>{{ group.name }}</td>
+        <td>{{ group.size }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+


### PR DESCRIPTION
## Summary
- add Top Institutions section tallying authors by affiliation for the Hall of Fame

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 "Forbidden" during gem fetch)*

------
https://chatgpt.com/codex/tasks/task_e_688fdfd4097883258ea51e7045b86a95