### PR TITLE
Add script to generate co-author data

### DIFF
--- a/_data/co-authors.yml
+++ b/_data/co-authors.yml
@@ -1,0 +1,419 @@
+- name: Aashaka Shah
+  last_coauthored: 2023
+  website: 
+
+- name: Aasheesh Kolli
+  last_coauthored: 2021
+  website: 
+
+- name: Abhishek Gupta
+  last_coauthored: 2020
+  website: 
+
+- name: Aditya Akella
+  last_coauthored: 2024
+  website: 
+
+- name: Aishwarya Ganesan
+  last_coauthored: 2018
+  website: 
+
+- name: Alexander Conway
+  last_coauthored: 2020
+  website: 
+
+- name: Amar Phanishayee
+  last_coauthored: 2022
+  website: 
+
+- name: Amy Tai
+  last_coauthored: 2021
+  website: 
+
+- name: Andrea C. Arpaci-Dusseau
+  last_coauthored: 2018
+  website: 
+
+- name: Arun Kumar
+  last_coauthored: 2020
+  website: 
+
+- name: Ashish Raniwala
+  last_coauthored: 2021
+  website: 
+
+- name: Ashlie Martinez
+  last_coauthored: 2018
+  website: 
+
+- name: Aws Albarghouthi
+  last_coauthored: 2018
+  website: 
+
+- name: Chao-Yuan Wu
+  last_coauthored: 2021
+  website: 
+
+- name: Cheng Huang
+  last_coauthored: 2025
+  website: 
+
+- name: Chris Hawblitzel
+  last_coauthored: 2025
+  website: 
+
+- name: Dahlia Malkhi
+  last_coauthored: 2021
+  website: 
+
+- name: Dhathri Purohith
+  last_coauthored: 2017
+  website: 
+
+- name: Dixin Tang
+  last_coauthored: 2025
+  website: 
+
+- name: Emmett Witchel
+  last_coauthored: 2025
+  website: 
+
+- name: Eric Lee
+  last_coauthored: 2018
+  website: 
+
+- name: Eric Schkufza
+  last_coauthored: 2016
+  website: 
+
+- name: Evan Kaminsky
+  last_coauthored: 2018
+  website: 
+
+- name: Gilad Oved
+  last_coauthored: 2018
+  website: 
+
+- name: Greg Ganger
+  last_coauthored: 2021
+  website: 
+
+- name: Gus Waldspurger
+  last_coauthored: 2025
+  website: 
+
+- name: HHaowei Chen
+  last_coauthored: 2025
+  website: 
+
+- name: Harshad Shirwadkar
+  last_coauthored: 2021
+  website: 
+
+- name: Haryadi S Gunawi
+  last_coauthored: 2025
+  website: 
+
+- name: Hayley LeBlanc
+  last_coauthored: 2025
+  website: 
+
+- name: Himanshu Chauhan
+  last_coauthored: 2016
+  website: 
+
+- name: Ian Neal
+  last_coauthored: 2018
+  website: 
+
+- name: Irina Calciu
+  last_coauthored: 2016
+  website: 
+
+- name: Ittai Abraham
+  last_coauthored: 2018
+  website: 
+
+- name: Işıl Dillig
+  last_coauthored: 2023
+  website: 
+
+- name: Jacob Nelson
+  last_coauthored: 2023
+  website: 
+
+- name: Jacob R. Lorch
+  last_coauthored: 2025
+  website: 
+
+- name: James Bornholt
+  last_coauthored: 2024
+  website: 
+
+- name: Janardhan Kulkarni
+  last_coauthored: 2022
+  website: 
+
+- name: Jason Haga
+  last_coauthored: 2022
+  website: 
+
+- name: Jayashree Mohan
+  last_coauthored: 2022
+  website: 
+
+- name: Jivko Sinapov
+  last_coauthored: 2017
+  website: 
+
+- name: John Bent
+  last_coauthored: 2025
+  website: 
+
+- name: Jos{\'e
+  last_coauthored: 2022
+  website: 
+
+- name: Kemas Wiharja
+  last_coauthored: 2025
+  website: 
+
+- name: Kimberly Keeton
+  last_coauthored: 2022
+  website: 
+
+- name: Lanyue Lu
+  last_coauthored: 2017
+  website: 
+
+- name: Madan Musuvathi
+  last_coauthored: 2023
+  website: 
+
+- name: Marcos K. Aguilera
+  last_coauthored: 2022
+  website: 
+
+- name: Martin Farach-Colton
+  last_coauthored: 2020
+  website: 
+
+- name: Matt Halpern
+  last_coauthored: 2017
+  website: 
+
+- name: Meghan Cowan
+  last_coauthored: 2023
+  website: 
+
+- name: Melissa Wasserman
+  last_coauthored: 2020
+  website: 
+
+- name: Meng Wang
+  last_coauthored: 2025
+  website: 
+
+- name: Michael Wei
+  last_coauthored: 2021
+  website: 
+
+- name: Nathan Taylor
+  last_coauthored: 2024
+  website: 
+
+- name: Naufal Ananda
+  last_coauthored: 2025
+  website: 
+
+- name: Newton Ni
+  last_coauthored: 2025
+  website: 
+
+- name: Nickolai Zeldovich
+  last_coauthored: 2025
+  website: 
+
+- name: Olli Saarikivi
+  last_coauthored: 2023
+  website: 
+
+- name: Om Saran
+  last_coauthored: 2023
+  website: 
+
+- name: Onur Mutlu
+  last_coauthored: 2016
+  website: 
+
+- name: Pandian Raju
+  last_coauthored: 2018
+  website: 
+
+- name: Peter Stone
+  last_coauthored: 2017
+  website: 
+
+- name: Philipp Kraehenbuehl
+  last_coauthored: 2021
+  website: 
+
+- name: Pratap Subrahmanyam
+  last_coauthored: 2016
+  website: 
+
+- name: Rachee Singh
+  last_coauthored: 2023
+  website: 
+
+- name: Ramnatthan Alagappan
+  last_coauthored: 2018
+  website: 
+
+- name: Remzi H. Arpaci-Dusseau
+  last_coauthored: 2018
+  website: 
+
+- name: Ricardo Macedo
+  last_coauthored: 2022
+  website: 
+
+- name: Richard Spillane
+  last_coauthored: 2020
+  website: 
+
+- name: Rob Johnson
+  last_coauthored: 2020
+  website: 
+
+- name: Rohan Kadedodi
+  last_coauthored: 2021
+  website: 
+
+- name: Rohan Kadekodi
+  last_coauthored: 2019
+  website: 
+
+- name: Saeed Maleki
+  last_coauthored: 2023
+  website: 
+
+- name: Sanidhya Kashyap
+  last_coauthored: 2019
+  website: 
+
+- name: Santiago Gonzalez
+  last_coauthored: 2017
+  website: 
+
+- name: Saurabh Kadekodi
+  last_coauthored: 2021
+  website: 
+
+- name: Se Kwon Lee
+  last_coauthored: 2019
+  website: 
+
+- name: Sekwon Lee
+  last_coauthored: 2022
+  website: 
+
+- name: Shankara Pailoor
+  last_coauthored: 2023
+  website: 
+
+- name: Sharad Singhal
+  last_coauthored: 2022
+  website: 
+
+- name: Soujanya Ponnapalli
+  last_coauthored: 2022
+  website: 
+
+- name: Souvik Banerjee
+  last_coauthored: 2021
+  website: 
+
+- name: Supreeth Shastri
+  last_coauthored: 2020
+  website: 
+
+- name: Swaminathan Sundararaman
+  last_coauthored: 2025
+  website: 
+
+- name: Taesoo Kim
+  last_coauthored: 2019
+  website: 
+
+- name: Thanumalayan Sankaranarayana Pillai
+  last_coauthored: 2017
+  website: 
+
+- name: Tianyu Cheng
+  last_coauthored: 2018
+  website: 
+
+- name: Todd Mytkowicz
+  last_coauthored: 2023
+  website: 
+
+- name: Vijay Janappa Reddi
+  last_coauthored: 2017
+  website: 
+
+- name: Vinay Banakar
+  last_coauthored: 2020
+  website: 
+
+- name: Yan Sun
+  last_coauthored: 2025
+  website: 
+
+- name: Yeonju Ro
+  last_coauthored: 2024
+  website: 
+
+- name: Yibo Huang
+  last_coauthored: 2025
+  website: 
+
+- name: Yige Hu
+  last_coauthored: 2018
+  website: 
+
+- name: Yiheng Tao
+  last_coauthored: 2025
+  website: 
+
+- name: Yougjin Kwon
+  last_coauthored: 2018
+  website: 
+
+- name: Younjin Kwon
+  last_coauthored: 2017
+  website: 
+
+- name: Yusuke Tanimura
+  last_coauthored: 2022
+  website: 
+
+- name: Yuyang Huang
+  last_coauthored: 2025
+  website: 
+
+- name: Zachary Keener
+  last_coauthored: 2018
+  website: 
+
+- name: Zhangyang Wang
+  last_coauthored: 2023
+  website: 
+
+- name: Zhenyu Zhang
+  last_coauthored: 2024
+  website: 
+
+- name: Zhiting Zhu
+  last_coauthored: 2018
+  website: 

--- a/update_coauthors.py
+++ b/update_coauthors.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Generate co-author data from the bibliography."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+BIB_PATH = Path("assets/ref.bib")
+OUTPUT_PATH = Path("_data/co-authors.yml")
+SELF_NAME = "Vijay Chidambaram"
+
+
+def normalize(name: str) -> str:
+    name = re.sub(r"\s+", " ", name.strip())
+    if "," in name:
+        last, first = [p.strip() for p in name.split(",", 1)]
+        name = f"{first} {last}"
+    return name
+
+
+def parse_entries(text: str):
+    pattern = re.compile(r"@.*?{[^@]*}", re.DOTALL)
+    for match in pattern.finditer(text):
+        yield match.group(0)
+
+
+def extract_authors_year(entry: str):
+    m_auth = re.search(r"author\s*=\s*{([^}]*)}", entry, re.IGNORECASE | re.DOTALL)
+    m_year = re.search(r"year\s*=\s*{([^}]*)}", entry, re.IGNORECASE)
+    if not (m_auth and m_year):
+        return None, None
+    year_text = m_year.group(1)
+    year_match = re.search(r"\d{4}", year_text)
+    year = int(year_match.group(0)) if year_match else None
+    authors_field = m_auth.group(1).replace("\n", " ")
+    authors = [normalize(a) for a in authors_field.split(" and ") if a.strip()]
+    return authors, year
+
+
+def main() -> None:
+    if not BIB_PATH.exists():
+        raise SystemExit(f"Input file {BIB_PATH} does not exist")
+    text = BIB_PATH.read_text(encoding="utf-8")
+    coauthors: dict[str, int] = {}
+    for entry in parse_entries(text):
+        authors, year = extract_authors_year(entry)
+        if not authors or year is None:
+            continue
+        normalized_self = normalize(SELF_NAME).lower()
+        normalized_authors = [normalize(a).lower() for a in authors]
+        if normalized_self not in normalized_authors:
+            continue
+        for author in authors:
+            if normalize(author).lower() == normalized_self:
+                continue
+            key = normalize(author)
+            coauthors[key] = max(year, coauthors.get(key, 0))
+    lines = []
+    for name in sorted(coauthors):
+        lines.append(f"- name: {name}")
+        lines.append(f"  last_coauthored: {coauthors[name]}")
+        lines.append("  website: ")
+        lines.append("")
+    OUTPUT_PATH.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote {len(coauthors)} co-authors to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `update_coauthors.py` to parse `assets/ref.bib` and build a YAML list of co-authors
- generate `_data/co-authors.yml` listing each co-author with the last year of collaboration and a placeholder for their website

## Testing
- `python update_coauthors.py`

------
https://chatgpt.com/codex/tasks/task_e_688ffa113fe083258c707917322b205a