### PR TITLE
Link co-author names to personal websites

### DIFF
--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -28,7 +28,13 @@ pre{
   {% if entry.author_array %}
     <br/>
     {% for author in entry.author_array %}
-      {{ author.first }} {{ author.last }}{% unless forloop.last %}, {% endunless %}
+      {% assign full_name = author.first | append: ' ' | append: author.last %}
+      {% assign coauthor = site.data['co-authors'] | where: 'name', full_name | first %}
+      {% if coauthor and coauthor.website %}
+        <a href="{{ coauthor.website }}">{{ author.first }} {{ author.last }}</a>{% unless forloop.last %}, {% endunless %}
+      {% else %}
+        {{ author.first }} {{ author.last }}{% unless forloop.last %}, {% endunless %}
+      {% endif %}
     {% endfor %}
   {% endif %}
   <br/>


### PR DESCRIPTION
## Summary
- link co-author names in publication listings to their personal websites when available in `_data/co-authors.yml`

## Testing
- `bundle exec jekyll build` *(fails: bundle: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68900a8ee5bc8325a75ef316962391cf