### PR TITLE
Sync publication types page header size and hide empty preprints

### DIFF
--- a/_pages/full-publications.md
+++ b/_pages/full-publications.md
@@ -17,18 +17,18 @@ years: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 
 {% capture preprints %}{% bibliography --template bibtemplate --query @unpublished %}{% endcapture %}
 {% assign preprints = preprints | strip %}
-{% unless preprints == "" %}
+{% if preprints contains 'publication-entry' %}
 <details class="jumbotron">
-<summary><h3>Preprints</h3></summary>
+<summary><h3 style="font-size: 1.2rem;">Preprints</h3></summary>
 {{ preprints }}
 </details>
-{% endunless %}
+{% endif %}
 
 {% capture conf %}{% bibliography --template bibtemplate --query @inproceedings[group != workshop] %}{% endcapture %}
 {% assign conf = conf | strip %}
 {% unless conf == "" %}
 <details class="jumbotron">
-<summary><h3>Refereed conference proceedings</h3></summary>
+<summary><h3 style="font-size: 1.2rem;">Refereed conference proceedings</h3></summary>
 {{ conf }}
 </details>
 {% endunless %}
@@ -37,7 +37,7 @@ years: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 {% assign journal = journal | strip %}
 {% unless journal == "" %}
 <details class="jumbotron">
-<summary><h3>Refereed journal articles</h3></summary>
+<summary><h3 style="font-size: 1.2rem;">Refereed journal articles</h3></summary>
 {{ journal }}
 </details>
 {% endunless %}
@@ -46,7 +46,7 @@ years: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 {% assign workshop = workshop | strip %}
 {% unless workshop == "" %}
 <details class="jumbotron">
-<summary><h3>Workshop papers</h3></summary>
+<summary><h3 style="font-size: 1.2rem;">Workshop papers</h3></summary>
 {{ workshop }}
 </details>
 {% endunless %}


### PR DESCRIPTION
## Summary
- Match publication-by-type section headers to the size of the "Publications by type" link
- Skip showing a Preprints section when there are no preprint entries

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_6890ededc76c83259f8d5a4b5de8096b