### PR TITLE
Preserve existing co-author info

### DIFF
--- a/update_coauthors.py
+++ b/update_coauthors.py
@@ -56,14 +56,52 @@ def main() -> None:
                 continue
             key = normalize(author)
             coauthors[key] = max(year, coauthors.get(key, 0))
+    existing: list[dict[str, str | int]] = []
+    if OUTPUT_PATH.exists():
+        current: dict[str, str | int] = {}
+        for line in OUTPUT_PATH.read_text(encoding="utf-8").splitlines():
+            line = line.rstrip()
+            if not line:
+                if current:
+                    existing.append(current)
+                    current = {}
+                continue
+            if line.startswith("- "):
+                if current:
+                    existing.append(current)
+                key, value = line[2:].split(":", 1)
+                value = value.strip()
+                current = {key.strip(): int(value) if key.strip() == "last_coauthored" else value}
+            else:
+                key, value = line.strip().split(":", 1)
+                value = value.strip()
+                current[key] = int(value) if key == "last_coauthored" else value
+        if current:
+            existing.append(current)
+    existing_map = {normalize(e["name"]).lower(): e for e in existing}
+
+    for name, year in coauthors.items():
+        key = normalize(name).lower()
+        if key in existing_map:
+            entry = existing_map[key]
+            entry["last_coauthored"] = max(year, int(entry.get("last_coauthored", 0)))
+        else:
+            entry = {"name": name, "last_coauthored": year, "website": ""}
+            existing.append(entry)
+            existing_map[key] = entry
+
+    existing.sort(key=lambda e: e["name"])
     lines = []
-    for name in sorted(coauthors):
-        lines.append(f"- name: {name}")
-        lines.append(f"  last_coauthored: {coauthors[name]}")
-        lines.append("  website: ")
+    for entry in existing:
+        lines.append(f"- name: {entry['name']}")
+        lines.append(f"  last_coauthored: {entry['last_coauthored']}")
+        for key, value in entry.items():
+            if key in {"name", "last_coauthored"}:
+                continue
+            lines.append(f"  {key}: {value}")
         lines.append("")
-    OUTPUT_PATH.write_text("\n".join(lines), encoding="utf-8")
-    print(f"Wrote {len(coauthors)} co-authors to {OUTPUT_PATH}")
+    OUTPUT_PATH.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    print(f"Wrote {len(existing)} co-authors to {OUTPUT_PATH}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep existing entries in `_data/co-authors.yml` when regenerating list
- update `last_coauthored` or append new co-authors without wiping other fields

## Testing
- `python update_coauthors.py`

------
https://chatgpt.com/codex/tasks/task_e_68910a72b4f88325b401b3edc295ced9