### PR TITLE
Number Alumni PhDs from bottom

### DIFF
--- a/_pages/team.md
+++ b/_pages/team.md
@@ -79,7 +79,12 @@ permalink: /team/
 ## Alumni
 
 <div class="jumbotron">
-{% assign phd_total = site.data.alumni | where_exp: "item", "item.duration contains 'PhD' and item.duration contains 'co-advised' == false" | size %}
+{% assign phd_total = 0 %}
+{% for a in site.data.alumni %}
+  {% if a.duration contains 'PhD' and a.duration contains 'co-advised' == false %}
+    {% assign phd_total = phd_total | plus: 1 %}
+  {% endif %}
+{% endfor %}
 {% assign phd_counter = phd_total %}
 {% assign number_printed = 0 %}
 {% for member in site.data.alumni %}

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -79,6 +79,8 @@ permalink: /team/
 ## Alumni
 
 <div class="jumbotron">
+{% assign phd_total = site.data.alumni | where_exp: "item", "item.duration contains 'PhD'" | size %}
+{% assign phd_counter = phd_total %}
 {% assign number_printed = 0 %}
 {% for member in site.data.alumni %}
 
@@ -94,7 +96,12 @@ permalink: /team/
 </div>
 <div class="col-sm-4 col-xs-12">
   <h4>{% if member.website %}<a href="{{ member.website }}" target="_blank">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</h4>
-  <i>{{ member.duration }} <br> Role: {{ member.info }}</i>
+  {% if member.duration contains 'PhD' %}
+    <i>PhD #{{ phd_counter }} <br> Role: {{ member.info }}</i>
+    {% assign phd_counter = phd_counter | minus: 1 %}
+  {% else %}
+    <i>{{ member.duration }} <br> Role: {{ member.info }}</i>
+  {% endif %}
   <ul style="overflow: hidden">
   </ul>
 </div>

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -79,7 +79,7 @@ permalink: /team/
 ## Alumni
 
 <div class="jumbotron">
-{% assign phd_total = site.data.alumni | where_exp: "item", "item.duration contains 'PhD'" | size %}
+{% assign phd_total = site.data.alumni | where_exp: "item", "item.duration contains 'PhD' and item.duration contains 'co-advised' == false" | size %}
 {% assign phd_counter = phd_total %}
 {% assign number_printed = 0 %}
 {% for member in site.data.alumni %}
@@ -96,11 +96,13 @@ permalink: /team/
 </div>
 <div class="col-sm-4 col-xs-12">
   <h4>{% if member.website %}<a href="{{ member.website }}" target="_blank">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</h4>
-  {% if member.duration contains 'PhD' %}
-    <i>PhD #{{ phd_counter }} <br> Role: {{ member.info }}</i>
+  {% if member.duration contains 'PhD' and member.duration contains 'co-advised' == false %}
+    <i>PhD #{{ phd_counter }}</i><br>
+    <i>Role: {{ member.info }}</i>
     {% assign phd_counter = phd_counter | minus: 1 %}
   {% else %}
-    <i>{{ member.duration }} <br> Role: {{ member.info }}</i>
+    <i>{{ member.duration }}</i><br>
+    <i>Role: {{ member.info }}</i>
   {% endif %}
   <ul style="overflow: hidden">
   </ul>

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -105,13 +105,13 @@ permalink: /team/
   <h4>{% if member.website %}<a href="{{ member.website }}" target="_blank">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</h4>
   {% if member.duration contains 'PhD' %}
     {% unless member.duration contains 'co-advised' %}
-      <i>PhD #{{ phd_counter }}</i><br>
-      {% assign phd_counter = phd_counter | minus: 1 %}
+  <i>PhD #{{ phd_counter }}</i><br>
+    {% assign phd_counter = phd_counter | minus: 1 %}
     {% else %}
-      <i>{{ member.duration }}</i><br>
+  <i>{{ member.duration }}</i><br>
     {% endunless %}
   {% else %}
-    <i>{{ member.duration }}</i><br>
+  <i>{{ member.duration }}</i><br>
   {% endif %}
   <i>Role: {{ member.info }}</i>
   <ul style="overflow: hidden">

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -81,8 +81,10 @@ permalink: /team/
 <div class="jumbotron">
 {% assign phd_total = 0 %}
 {% for a in site.data.alumni %}
-  {% if a.duration contains 'PhD' and a.duration contains 'co-advised' == false %}
-    {% assign phd_total = phd_total | plus: 1 %}
+  {% if a.duration contains 'PhD' %}
+    {% unless a.duration contains 'co-advised' %}
+      {% assign phd_total = phd_total | plus: 1 %}
+    {% endunless %}
   {% endif %}
 {% endfor %}
 {% assign phd_counter = phd_total %}
@@ -101,14 +103,17 @@ permalink: /team/
 </div>
 <div class="col-sm-4 col-xs-12">
   <h4>{% if member.website %}<a href="{{ member.website }}" target="_blank">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</h4>
-  {% if member.duration contains 'PhD' and member.duration contains 'co-advised' == false %}
-    <i>PhD #{{ phd_counter }}</i><br>
-    <i>Role: {{ member.info }}</i>
-    {% assign phd_counter = phd_counter | minus: 1 %}
+  {% if member.duration contains 'PhD' %}
+    {% unless member.duration contains 'co-advised' %}
+      <i>PhD #{{ phd_counter }}</i><br>
+      {% assign phd_counter = phd_counter | minus: 1 %}
+    {% else %}
+      <i>{{ member.duration }}</i><br>
+    {% endunless %}
   {% else %}
     <i>{{ member.duration }}</i><br>
-    <i>Role: {{ member.info }}</i>
   {% endif %}
+  <i>Role: {{ member.info }}</i>
   <ul style="overflow: hidden">
   </ul>
 </div>


### PR DESCRIPTION
## Summary
- Count all PhD alumni and label each one from the bottom up (PhD #1, PhD #2, etc.)

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68911051393c83259023ffccae790fdc