### PR TITLE
feat: add hall of fame author flair

### DIFF
--- a/_pages/hall-of-fame.md
+++ b/_pages/hall-of-fame.md
@@ -53,7 +53,7 @@ Reflects data up-to OSDI 25.
         {% endfor %}
         <tr>
           <td>{{ rank }}</td>
-          <td><a href="{{ author.dblp }}">{{ author.name }}</a></td>
+          <td><a href="{{ author.dblp }}">{{ author.name }}</a>{% assign lastfive = author.lastfive | plus: 0 %}{% if lastfive >= 15 %} 🚀{% elsif lastfive >= 10 %} 🔥🔥{% elsif lastfive >= 5 %} 🔥{% endif %}</td>
           <td>{{ affiliation }}</td>
           <td>{{ author.freq }}</td>
           <td>{{ author.lastfive }}</td>


### PR DESCRIPTION
## Summary
- show emoji next to Hall of Fame authors based on recent publications

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6894cbb4bef08325b3c353daa1ddd151