### PR TITLE
Sort publications by year, volume, and issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,7 +74,7 @@ scholar:
   source: /assets/
   bibliography: ref.bib
   bibliography_template: bibtemplate
-  sort_by: year, month
+  sort_by: year, volume, number
   order: descending
 
   replace_strings: true


### PR DESCRIPTION
## Summary
- Sort publications by year, then volume and issue when available by adjusting Jekyll Scholar configuration

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden" while fetching gems)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6895287fff948325aafe78d9c943c28f