### PR TITLE
Wrap recent publications in grey box on home page

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -24,7 +24,9 @@ Research group out at lunch in 2018!
 </div>
 <br/>
 
+<div class="jumbotron">
 ##### <u>Recent Publications</u>
 
 {% bibliography --template bibtemplate --max 3 %}
+</div>
 


### PR DESCRIPTION
## Summary
- Display recent publications within a jumbotron so they appear in a grey box like the news section

## Testing
- `bundle install` *(hangs while compiling native extensions)*
- `bundle exec jekyll build` *(bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68974abd7a148325a8001cdd3b576176