### PR TITLE
Fix alumni spacing on Team page

### DIFF
--- a/_pages/team.md
+++ b/_pages/team.md
@@ -105,15 +105,15 @@ permalink: /team/
   <h4>{% if member.website %}<a href="{{ member.website }}" target="_blank">{{ member.name }}</a>{% else %}{{ member.name }}{% endif %}</h4>
   {% if member.duration contains 'PhD' %}
     {% unless member.duration contains 'co-advised' %}
-  <i>PhD #{{ phd_counter }}</i><br>
+  <i style="display:block;">PhD #{{ phd_counter }}</i>
     {% assign phd_counter = phd_counter | minus: 1 %}
     {% else %}
-  <i>{{ member.duration }}</i><br>
+  <i style="display:block;">{{ member.duration }}</i>
     {% endunless %}
   {% else %}
-  <i>{{ member.duration }}</i><br>
+  <i style="display:block;">{{ member.duration }}</i>
   {% endif %}
-  <i>Role: {{ member.info }}</i>
+  <i style="display:block;">Role: {{ member.info }}</i>
   <ul style="overflow: hidden">
   </ul>
 </div>


### PR DESCRIPTION
## Summary
- remove extra whitespace between alumni PhD numbering and role lines by using block-level styling

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(installed dependencies)*
- `gem install jekyll` *(attempted, interrupted due to stream closed)*

------
https://chatgpt.com/codex/tasks/task_e_68976584591483259855625f0e417182