### PR TITLE
Fix spacing for publication keywords

### DIFF
--- a/_pages/publications-by-topic.md
+++ b/_pages/publications-by-topic.md
@@ -28,7 +28,7 @@ permalink: /publications-by-topic/
 <div markdown="0">
 {% for keyword in site.data.sorted_keywords %}
 <details class="jumbotron">
-  <summary><h3 style="font-size: 1.2rem;">{{ keyword }}</h3></summary>
+  <summary style="font-size: 1.2rem; font-weight: 600;">{{ keyword }}</summary>
   <div class="year-list">
     {% assign total_pubs = site.data.publications_by_keyword[keyword] | size %}
     {% for entry in site.data.publications_by_keyword[keyword] %}


### PR DESCRIPTION
## Summary
- Display topic keywords directly in the `<summary>` tag so they align with the collapse arrow and avoid extra spacing.

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689773c1016c8325b520a3c471c302cf