### PR TITLE
Display awards for publications

### DIFF
--- a/_includes/publication_entry.html
+++ b/_includes/publication_entry.html
@@ -54,7 +54,8 @@ pre{
     <em>{{ entry.publisher | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}</em>
   {% endif %}
   {% if entry.award %}
-    <br/>🏆 {{ entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}
+    {% assign award_clean = entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace %}
+    <br/>🏆 <span style="color: yellow; font-weight: bold;">{{ award_clean | capitalize }}</span>
   {% endif %}
   </div>
 

--- a/_includes/publication_entry.html
+++ b/_includes/publication_entry.html
@@ -53,6 +53,9 @@ pre{
   {% elsif entry.publisher %}
     <em>{{ entry.publisher | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}</em>
   {% endif %}
+  {% if entry.award %}
+    <br/>🏆 {{ entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}
+  {% endif %}
   </div>
 
   <!-- You can use the below to make your name bold -->

--- a/_includes/publication_entry.html
+++ b/_includes/publication_entry.html
@@ -55,7 +55,7 @@ pre{
   {% endif %}
   {% if entry.award %}
     {% assign award_clean = entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace %}
-    <br/>🏆 <span style="color: yellow; font-weight: bold;">{{ award_clean | capitalize }}</span>
+    <br/>🏆 <span class="text-warning font-weight-bold">{{ award_clean | capitalize }}</span>
   {% endif %}
   </div>
 

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -61,7 +61,8 @@ pre{
     <em>{{ entry.publisher | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}</em>
   {% endif %}
   {% if entry.award %}
-    <br/>🏆 {{ entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}
+    {% assign award_clean = entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace %}
+    <br/>🏆 <span style="color: yellow; font-weight: bold;">{{ award_clean | capitalize }}</span>
   {% endif %}
   </div>
 

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -29,7 +29,9 @@ pre{
 
 <div class="publication-entry">
   <div class="text-justify">
-    <strong>{{ entry.title | unescape_tilde }}</strong>
+    {%- assign open_brace = '{' -%}
+    {%- assign close_brace = '}' -%}
+    <strong>{{ entry.title | unescape_tilde | remove: open_brace | remove: close_brace }}</strong>
   {% if entry.author_array %}
     <br/>
     {% for author in entry.author_array %}
@@ -52,14 +54,14 @@ pre{
   {% endif %}
   <br/>
   {% if entry.booktitle %}
-    <em>{{ entry.booktitle | remove: '"' | unescape_tilde }}</em>
+    <em>{{ entry.booktitle | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}</em>
   {% elsif entry.journal %}
-    <em>{{ entry.journal | remove: '"' | unescape_tilde }}{% if entry.volume %}, Volume {{ entry.volume }}{% endif %}{% if entry.number %}, Issue {{ entry.number }}{% endif %}</em>
+    <em>{{ entry.journal | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}{% if entry.volume %}, Volume {{ entry.volume }}{% endif %}{% if entry.number %}, Issue {{ entry.number }}{% endif %}</em>
   {% elsif entry.publisher %}
-    <em>{{ entry.publisher | remove: '"' | unescape_tilde }}</em>
+    <em>{{ entry.publisher | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}</em>
   {% endif %}
   {% if entry.award %}
-    <br/>🏆 {{ entry.award | remove: '"' | unescape_tilde | remove: '{' | remove: '}' }}
+    <br/>🏆 {{ entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace }}
   {% endif %}
   </div>
 

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -62,7 +62,7 @@ pre{
   {% endif %}
   {% if entry.award %}
     {% assign award_clean = entry.award | remove: '"' | unescape_tilde | remove: open_brace | remove: close_brace %}
-    <br/>🏆 <span style="color: yellow; font-weight: bold;">{{ award_clean | capitalize }}</span>
+    <br/>🏆 <span class="text-warning font-weight-bold">{{ award_clean | capitalize }}</span>
   {% endif %}
   </div>
 

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -58,6 +58,9 @@ pre{
   {% elsif entry.publisher %}
     <em>{{ entry.publisher | remove: '"' | unescape_tilde }}</em>
   {% endif %}
+  {% if entry.award %}
+    <br/>🏆 {{ entry.award | remove: '"' | unescape_tilde | remove: '{' | remove: '}' }}
+  {% endif %}
   </div>
 
   <!-- You can use the below to make your name bold -->


### PR DESCRIPTION
## Summary
- Show award information beneath publication venue with a trophy icon on all publication-related pages

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6897bd5eb0f483259b270609477a5e2c