### PR TITLE
Show GitHub star badge for software links in publications

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,4 +25,3 @@
 </div>
 
   <script src="{{ "/assets/javascript/bootstrap/bootstrap.bundle.min.js" | absolute_url }}"></script>
-  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,3 +25,4 @@
 </div>
 
   <script src="{{ "/assets/javascript/bootstrap/bootstrap.bundle.min.js" | absolute_url }}"></script>
+  <script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/_includes/publication_entry.html
+++ b/_includes/publication_entry.html
@@ -89,10 +89,6 @@ pre{
 {% if entry.slides %}
 <a href="{{ entry.slides | unescape_tilde }}" target="_blank"><button class="btn btn-info btm-sm">SLIDES</button></a>
 {% endif %}
-{% if entry.software %}
-  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
-  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
-{% endif %}
 {% if entry.video %}
 <a href="{{ entry.video | unescape_tilde }}" target="_blank"><button class="btn btn-media btm-sm">VIDEO</button></a>
 {% endif %}
@@ -111,6 +107,11 @@ pre{
 
 {% if entry.abstract %}
 <button class="btn btn-warning btm-sm"  onclick="toggleAbstract('{{entry.key}}{{ id_suffix }}')">ABSTRACT</button>
+{% endif %}
+
+{% if entry.software %}
+  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
+  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
 {% endif %}
 
 {% if entry.abstract %}
@@ -146,4 +147,3 @@ function toggleAbstract(key) {
     }
 }
 </script>
-<script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/_includes/publication_entry.html
+++ b/_includes/publication_entry.html
@@ -110,8 +110,7 @@ pre{
 {% endif %}
 
 {% if entry.software %}
-  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
-  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
+  <a href="{{ entry.software | unescape_tilde }}" target="_blank"><button class="btn btn-code btm-sm">CODE</button></a>
 {% endif %}
 
 {% if entry.abstract %}

--- a/_includes/publication_entry.html
+++ b/_includes/publication_entry.html
@@ -89,6 +89,10 @@ pre{
 {% if entry.slides %}
 <a href="{{ entry.slides | unescape_tilde }}" target="_blank"><button class="btn btn-info btm-sm">SLIDES</button></a>
 {% endif %}
+{% if entry.software %}
+  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
+  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
+{% endif %}
 {% if entry.video %}
 <a href="{{ entry.video | unescape_tilde }}" target="_blank"><button class="btn btn-media btm-sm">VIDEO</button></a>
 {% endif %}
@@ -142,3 +146,4 @@ function toggleAbstract(key) {
     }
 }
 </script>
+<script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -117,8 +117,7 @@ pre{
 {% endif %}
 
 {% if entry.software %}
-  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
-  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
+  <a href="{{ entry.software | unescape_tilde }}" target="_blank"><button class="btn btn-code btm-sm">CODE</button></a>
 {% endif %}
 
 {% if entry.abstract %}

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -96,10 +96,6 @@ pre{
 {% if entry.slides %}
 <a href="{{ entry.slides | unescape_tilde }}" target="_blank"><button class="btn btn-info btm-sm">SLIDES</button></a>
 {% endif %}
-{% if entry.software %}
-  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
-  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
-{% endif %}
 {% if entry.video %}
 <a href="{{ entry.video | unescape_tilde }}" target="_blank"><button class="btn btn-media btm-sm">VIDEO</button></a>
 {% endif %}
@@ -118,6 +114,11 @@ pre{
 
 {% if entry.abstract %}
 <button class="btn btn-warning btm-sm"  onclick="toggleAbstract('{{entry.key}}{{ id_suffix }}')">ABSTRACT</button>
+{% endif %}
+
+{% if entry.software %}
+  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
+  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
 {% endif %}
 
 {% if entry.abstract %}
@@ -153,4 +154,3 @@ function toggleAbstract(key) {
     }
 }
 </script>
-<script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/_layouts/bibtemplate.html
+++ b/_layouts/bibtemplate.html
@@ -96,6 +96,10 @@ pre{
 {% if entry.slides %}
 <a href="{{ entry.slides | unescape_tilde }}" target="_blank"><button class="btn btn-info btm-sm">SLIDES</button></a>
 {% endif %}
+{% if entry.software %}
+  {% assign repo_name = entry.software | remove: 'https://github.com/' %}
+  <a class="github-button" href="{{ entry.software | unescape_tilde }}" data-icon="octicon-star" data-show-count="true" aria-label="Star {{ repo_name }} on GitHub">Star</a>
+{% endif %}
 {% if entry.video %}
 <a href="{{ entry.video | unescape_tilde }}" target="_blank"><button class="btn btn-media btm-sm">VIDEO</button></a>
 {% endif %}
@@ -149,3 +153,4 @@ function toggleAbstract(key) {
     }
 }
 </script>
+<script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -48,5 +48,3 @@ permalink: /publications/
   </tr>
 </table>
 
-<script async defer src="https://buttons.github.io/buttons.js"></script>
-

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -31,8 +31,8 @@ permalink: /publications/
     <td style="text-align: right;">Presentation slides</td>
   </tr>
   <tr>
-    <td><a class="github-button" href="https://github.com/github/docs" data-icon="octicon-star" data-show-count="true" aria-label="Star github/docs on GitHub">Star</a></td>
-    <td style="text-align: right;">GitHub repository with star count</td>
+    <td><button class="btn btn-code btm-sm">CODE</button></td>
+    <td style="text-align: right;">GitHub repository</td>
   </tr>
   <tr>
     <td><button class="btn btn-media btm-sm">VIDEO</button></td>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -31,6 +31,10 @@ permalink: /publications/
     <td style="text-align: right;">Presentation slides</td>
   </tr>
   <tr>
+    <td><a class="github-button" href="https://github.com/github/docs" data-icon="octicon-star" data-show-count="true" aria-label="Star github/docs on GitHub">Star</a></td>
+    <td style="text-align: right;">GitHub repository with star count</td>
+  </tr>
+  <tr>
     <td><button class="btn btn-media btm-sm">VIDEO</button></td>
     <td style="text-align: right;">Recorded presentation or related video</td>
   </tr>
@@ -43,4 +47,6 @@ permalink: /publications/
     <td style="text-align: right;">BibTeX citation</td>
   </tr>
 </table>
+
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 

--- a/_plugins/keywords_generator.rb
+++ b/_plugins/keywords_generator.rb
@@ -35,6 +35,7 @@ module Jekyll
         pub_hash['pdf'] = entry.pdf.to_s if entry.respond_to?(:pdf) && entry.pdf
         pub_hash['doi'] = entry.doi.to_s if entry.respond_to?(:doi) && entry.doi
         pub_hash['slides'] = entry.slides.to_s if entry.respond_to?(:slides) && entry.slides
+        pub_hash['software'] = entry.software.to_s if entry.respond_to?(:software) && entry.software
         pub_hash['video'] = entry.video.to_s if entry.respond_to?(:video) && entry.video
         pub_hash['audio'] = entry.audio.to_s if entry.respond_to?(:audio) && entry.audio
         pub_hash['abstract'] = entry.abstract.to_s if entry.respond_to?(:abstract) && entry.abstract

--- a/_sass/SHB_css.scss
+++ b/_sass/SHB_css.scss
@@ -43,6 +43,30 @@ img {
     border-color: #6f42c1;
 }
 
+/* Orange code buttons for GitHub repository links */
+.btn-code {
+    color: #fff;
+    background-color: #f46b01;
+    border-color: #f46b01;
+}
+
+.btn-code:hover,
+.btn-code:focus,
+.btn-code:active,
+.btn-code.active,
+.show > .btn-code.dropdown-toggle {
+    color: #fff;
+    background-color: darken(#f46b01, 7.5%);
+    border-color: darken(#f46b01, 10%);
+}
+
+.btn-code:disabled,
+.btn-code.disabled {
+    color: #fff;
+    background-color: #f46b01;
+    border-color: #f46b01;
+}
+
 .container-fluid {
   max-width: 800px;
 }

--- a/assets/ref.bib
+++ b/assets/ref.bib
@@ -155,7 +155,7 @@
   video =	 {https://www.youtube.com/watch?v=oyrWI2LaDq8},
   slides =
                   {https://www.usenix.org/system/files/atc21_slides_ponnapalli.pdf},
-  software =	 {https://github.com/RainBlock}
+  software =     {https://github.com/RainBlock/rainblock-protocol}
 }
 
 @inproceedings{chipmunk-eurosys23,


### PR DESCRIPTION
## Summary
- Display GitHub star button when a bibliography entry lists a software repository
- Load GitHub button script in publication templates and update legend
- Mention GitHub repository star button in publications page legend

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(partial install; terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e96c0e88325991a156721d7abde