### PR TITLE
Fix Hall of Fame lastfive counts after name sanitization

### DIFF
--- a/_data/hof.csv
+++ b/_data/hof.csv
@@ -1,110 +1,110 @@
 name,last,affiliation,freq,lastfive,dblp,orcid
-M. Frans Kaashoek,Kaashoek,"MIT, Cambridge, USA",49,0,https://dblp.org/pid/k/MFransKaashoek,https://orcid.org/0000-0001-7098-586X
-Nickolai Zeldovich,Zeldovich,"Massachusetts Institute of Technology, Cambridge, USA",39,0,https://dblp.org/pid/99/5780,
-Haibo Chen,Chen,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems,China",31,0,https://dblp.org/pid/31/6601-1,https://orcid.org/0000-0002-9720-0361
-Ion Stoica,Stoica,"University of California, Berkeley, USA",28,0,https://dblp.org/pid/s/IonStoica,https://orcid.org/0000-0002-5373-0088
-Gregory R. Ganger,Ganger,"Carnegie Mellon University, Pittsburgh, USA",23,0,https://dblp.org/pid/g/GregoryRGanger,https://orcid.org/0000-0002-3065-7316
-Lidong Zhou,Zhou,Microsoft Research,23,0,https://dblp.org/pid/z/LidongZhou,https://orcid.org/0000-0002-7258-3116
-Andrea C. Arpaci-Dusseau,Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,0,https://dblp.org/pid/a/AndreaCArpaciDusseau,https://orcid.org/0000-0001-8618-2738
-Remzi H. Arpaci-Dusseau,Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,0,https://dblp.org/pid/a/RemziHArpaciDusseau,https://orcid.org/0000-0001-9965-7704
-Henry M. Levy,Levy,"University of Washington, Seattle, Washington, USA",20,0,https://dblp.org/pid/l/HenryMLevy,https://orcid.org/0009-0008-7786-8541
-Jason Flinn,Flinn,Facebook,20,0,https://dblp.org/pid/14/85,
-David Mazières,Mazières,"Stanford University, Department of Computer Science, CA, USA",19,0,https://dblp.org/pid/m/DMazieres,https://orcid.org/0000-0002-1253-6449
-Fan Yang,Yang,"Microsoft Research Asia, Beijing, China",18,0,https://dblp.org/pid/29/3081-24,https://orcid.org/0000-0002-0378-060X
-Jason Nieh,Nieh,"Columbia University, New York City, USA",17,0,https://dblp.org/pid/n/JasonNieh,https://orcid.org/0009-0005-8301-4479
-Ding Yuan,Yuan,"University of Toronto, Toronto, Canada",17,0,https://dblp.org/pid/230/9043-4,https://orcid.org/0000-0001-6322-0295
+M. Frans Kaashoek,Kaashoek,"MIT, Cambridge, USA",49,9,https://dblp.org/pid/k/MFransKaashoek,https://orcid.org/0000-0001-7098-586X
+Nickolai Zeldovich,Zeldovich,"Massachusetts Institute of Technology, Cambridge, USA",39,11,https://dblp.org/pid/99/5780,
+Haibo Chen,Chen,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems,China",31,22,https://dblp.org/pid/31/6601-1,https://orcid.org/0000-0002-9720-0361
+Ion Stoica,Stoica,"University of California, Berkeley, USA",28,7,https://dblp.org/pid/s/IonStoica,https://orcid.org/0000-0002-5373-0088
+Gregory R. Ganger,Ganger,"Carnegie Mellon University, Pittsburgh, USA",23,10,https://dblp.org/pid/g/GregoryRGanger,https://orcid.org/0000-0002-3065-7316
+Lidong Zhou,Zhou,Microsoft Research,23,10,https://dblp.org/pid/z/LidongZhou,https://orcid.org/0000-0002-7258-3116
+Andrea C. Arpaci-Dusseau,Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,3,https://dblp.org/pid/a/AndreaCArpaciDusseau,https://orcid.org/0000-0001-8618-2738
+Remzi H. Arpaci-Dusseau,Arpaci-Dusseau,"University of Wisconsin-Madison, Madison, WI, USA",21,2,https://dblp.org/pid/a/RemziHArpaciDusseau,https://orcid.org/0000-0001-9965-7704
+Henry M. Levy,Levy,"University of Washington, Seattle, Washington, USA",20,2,https://dblp.org/pid/l/HenryMLevy,https://orcid.org/0009-0008-7786-8541
+Jason Flinn,Flinn,Facebook,20,4,https://dblp.org/pid/14/85,
+David Mazières,Mazières,"Stanford University, Department of Computer Science, CA, USA",19,3,https://dblp.org/pid/m/DMazieres,https://orcid.org/0000-0002-1253-6449
+Fan Yang,Yang,"Microsoft Research Asia, Beijing, China",18,14,https://dblp.org/pid/29/3081-24,https://orcid.org/0000-0002-0378-060X
+Jason Nieh,Nieh,"Columbia University, New York City, USA",17,8,https://dblp.org/pid/n/JasonNieh,https://orcid.org/0009-0005-8301-4479
+Ding Yuan,Yuan,"University of Toronto, Toronto, Canada",17,6,https://dblp.org/pid/230/9043-4,https://orcid.org/0000-0001-6322-0295
 Barbara Liskov,Liskov,Massachusetts Institute of Technology,17,0,https://dblp.org/pid/l/BarbaraLiskov,
 Thomas E. Anderson,Anderson,"University of Washington, Seattle, Washington, USA",16,0,https://dblp.org/pid/a/ThomasEAnderson,https://orcid.org/0009-0004-2951-0343
-Shan Lu,Lu,"Microsoft Research, Redmond, WA, USA",16,0,https://dblp.org/pid/31/5916-1,https://orcid.org/0000-0002-0757-4600
-Emmett Witchel,Witchel,,15,0,https://dblp.org/pid/76/6082,https://orcid.org/0000-0002-1391-2880
+Shan Lu,Lu,"Microsoft Research, Redmond, WA, USA",16,6,https://dblp.org/pid/31/5916-1,https://orcid.org/0000-0002-0757-4600
+Emmett Witchel,Witchel,,15,5,https://dblp.org/pid/76/6082,https://orcid.org/0000-0002-1391-2880
 Junfeng Yang,Yang,,15,0,https://dblp.org/pid/71/3724,
-Amin Vahdat,Vahdat,Google,15,0,https://dblp.org/pid/v/AminVahdat,https://orcid.org/0000-0002-4866-1698
-Yuanyuan Zhou,Zhou,"University of California, San Diego, CA, USA",15,0,https://dblp.org/pid/99/2747-1,https://orcid.org/0000-0003-4760-7208
-Rong Chen,Chen,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems, China",15,0,https://dblp.org/pid/22/6904-1,https://orcid.org/0000-0002-6115-8130
-Robert Morris,Morris,"Massachusetts Institute of Technology (MIT), Cambridge, MA, USA",15,0,https://dblp.org/pid/82/11191,https://orcid.org/0009-0009-6885-0208
-Lorenzo Alvisi,Alvisi,"University of Texas at Austin, USA",15,0,https://dblp.org/pid/a/LAlvisi,https://orcid.org/0000-0002-9857-5528
+Amin Vahdat,Vahdat,Google,15,1,https://dblp.org/pid/v/AminVahdat,https://orcid.org/0000-0002-4866-1698
+Yuanyuan Zhou,Zhou,"University of California, San Diego, CA, USA",15,1,https://dblp.org/pid/99/2747-1,https://orcid.org/0000-0003-4760-7208
+Rong Chen,Chen,"Shanghai Jiao Tong University, Institute of Parallel and Distributed Systems, China",15,9,https://dblp.org/pid/22/6904-1,https://orcid.org/0000-0002-6115-8130
+Robert Morris,Morris,"Massachusetts Institute of Technology (MIT), Cambridge, MA, USA",15,1,https://dblp.org/pid/82/11191,https://orcid.org/0009-0009-6885-0208
+Lorenzo Alvisi,Alvisi,"University of Texas at Austin, USA",15,3,https://dblp.org/pid/a/LAlvisi,https://orcid.org/0000-0002-9857-5528
 Brian N. Bershad,Bershad,"University of Washington, Seattle, Washington, USA",15,0,https://dblp.org/pid/b/BNBershad,
-Taesoo Kim,Kim,,14,0,https://dblp.org/pid/38/8882,
-Simon Peter,Peter,"University of Washington, Seattle, WA, USA",14,0,https://dblp.org/pid/43/3917,https://orcid.org/0009-0007-4748-8524
-Arvind Krishnamurthy,Krishnamurthy,"University of Washington, Seattle, Washington, USA",14,0,https://dblp.org/pid/k/AKrishnamurthy,
-Jon Howell,Howell,,13,0,https://dblp.org/pid/55/3274,
-Sanidhya Kashyap,Kashyap,,13,0,https://dblp.org/pid/145/0912,
+Taesoo Kim,Kim,,14,4,https://dblp.org/pid/38/8882,
+Simon Peter,Peter,"University of Washington, Seattle, WA, USA",14,5,https://dblp.org/pid/43/3917,https://orcid.org/0009-0007-4748-8524
+Arvind Krishnamurthy,Krishnamurthy,"University of Washington, Seattle, Washington, USA",14,4,https://dblp.org/pid/k/AKrishnamurthy,
+Jon Howell,Howell,,13,3,https://dblp.org/pid/55/3274,
+Sanidhya Kashyap,Kashyap,,13,8,https://dblp.org/pid/145/0912,
 Roger M. Needham,Needham,Microsoft Research,13,0,https://dblp.org/pid/n/RogerNeedham,
-Bryan Ford,Ford,"Swiss Federal Institute of Technology in Lausanne (EPFL), Switzerland",13,0,https://dblp.org/pid/f/BryanFord,https://orcid.org/0000-0002-0528-3033
+Bryan Ford,Ford,"Swiss Federal Institute of Technology in Lausanne (EPFL), Switzerland",13,1,https://dblp.org/pid/f/BryanFord,https://orcid.org/0000-0002-0528-3033
 Michael Dahlin,Dahlin,"University of Texas at Austin, USA",13,0,https://dblp.org/pid/d/MDahlin,
 Miguel Castro,Castro,"Microsoft Research, Cambridge, UK",13,0,https://dblp.org/pid/c/MiguelCastro,
-Xin Jin,Jin,"Peking University, China",13,0,https://dblp.org/pid/68/3340-8,https://orcid.org/0000-0001-8741-5847
+Xin Jin,Jin,"Peking University, China",13,8,https://dblp.org/pid/68/3340-8,https://orcid.org/0000-0001-8741-5847
 Larry L. Peterson,Peterson,"Princeton University, USA",13,0,https://dblp.org/pid/p/LLPeterson,
 Xi Wang,Wang,"University of Washington, Seattle, WA, USA",13,0,https://dblp.org/pid/08/5760-5,
-Eddie Kohler,Kohler,Harvard University,13,0,https://dblp.org/pid/78/5231,https://orcid.org/0000-0003-2027-0035
-Scott Shenker,Shenker,"University of California, Berkeley, USA",13,0,https://dblp.org/pid/34/5593,https://orcid.org/0000-0002-1357-7533
-Peter Druschel,Druschel,Max Planck Institute for Software Systems,13,0,https://dblp.org/pid/d/PDruschel,https://orcid.org/0000-0002-7239-1114
-Chunqiang Tang,Tang,,12,0,https://dblp.org/pid/81/4301,
-Michael Stumm,Stumm,,12,0,https://dblp.org/pid/82/5150,
-Manos Kapritsos,Kapritsos,,12,0,https://dblp.org/pid/23/6695,https://orcid.org/0000-0002-4368-7418
-Kaushik Veeraraghavan,Veeraraghavan,,12,0,https://dblp.org/pid/52/1896,
-Wyatt Lloyd,Lloyd,,12,0,https://dblp.org/pid/21/1059,
-Tianyin Xu,Xu,"University of Illinois at Urbana-Champaign, Department of Computer Science, Urbana, IL, USA",12,0,https://dblp.org/pid/90/7566,https://orcid.org/0000-0003-4443-8170
+Eddie Kohler,Kohler,Harvard University,13,1,https://dblp.org/pid/78/5231,https://orcid.org/0000-0003-2027-0035
+Scott Shenker,Shenker,"University of California, Berkeley, USA",13,2,https://dblp.org/pid/34/5593,https://orcid.org/0000-0002-1357-7533
+Peter Druschel,Druschel,Max Planck Institute for Software Systems,13,1,https://dblp.org/pid/d/PDruschel,https://orcid.org/0000-0002-7239-1114
+Chunqiang Tang,Tang,,12,10,https://dblp.org/pid/81/4301,
+Michael Stumm,Stumm,,12,1,https://dblp.org/pid/82/5150,
+Manos Kapritsos,Kapritsos,,12,4,https://dblp.org/pid/23/6695,https://orcid.org/0000-0002-4368-7418
+Kaushik Veeraraghavan,Veeraraghavan,,12,3,https://dblp.org/pid/52/1896,
+Wyatt Lloyd,Lloyd,,12,2,https://dblp.org/pid/21/1059,
+Tianyin Xu,Xu,"University of Illinois at Urbana-Champaign, Department of Computer Science, Urbana, IL, USA",12,7,https://dblp.org/pid/90/7566,https://orcid.org/0000-0003-4443-8170
 Dawson R. Engler,Engler,"Stanford University, USA",12,0,https://dblp.org/pid/e/DREngler,
-Peng Huang,Huang,"University of Michigan, Ann Arbor, USA",12,0,https://dblp.org/pid/29/1726-5,https://orcid.org/0000-0001-6315-0848
+Peng Huang,Huang,"University of Michigan, Ann Arbor, USA",12,6,https://dblp.org/pid/29/1726-5,https://orcid.org/0000-0001-6315-0848
 Peter M. Chen,Chen,"University of Michigan, Ann Arbor, USA",12,0,https://dblp.org/pid/c/PeterMChen,
-Matei Zaharia,Zaharia,"Stanford University, CA, USA",12,0,https://dblp.org/pid/36/2133,https://orcid.org/0000-0002-7547-7204
-Mao Yang,Yang,"Microsoft Research, Beijing, China",12,0,https://dblp.org/pid/89/1482-4,https://orcid.org/0009-0009-6455-3898
-Chris Hawblitzel,Hawblitzel,,11,0,https://dblp.org/pid/22/3053,
-Lingxiao Ma,Ma,,11,0,https://dblp.org/pid/57/3203,
-Tej Chajed,Chajed,,11,0,https://dblp.org/pid/141/9176,
-Marcos K. Aguilera,Aguilera,"VMware, Palo Alto, CA, USA",11,0,https://dblp.org/pid/10/553,https://orcid.org/0000-0003-3489-2468
-Vijay Chidambaram,Chidambaram,"University of Texas at Austin, Department of Computer Science, TX, USA",11,0,https://dblp.org/pid/07/10563,https://orcid.org/0000-0001-7985-6087
-George Candea,Candea,"Swiss Federal Institute of Technology in Lausanne, Switzerland",11,0,https://dblp.org/pid/c/GeorgeCandea,https://orcid.org/0009-0002-8107-6535
+Matei Zaharia,Zaharia,"Stanford University, CA, USA",12,3,https://dblp.org/pid/36/2133,https://orcid.org/0000-0002-7547-7204
+Mao Yang,Yang,"Microsoft Research, Beijing, China",12,10,https://dblp.org/pid/89/1482-4,https://orcid.org/0009-0009-6455-3898
+Chris Hawblitzel,Hawblitzel,,11,4,https://dblp.org/pid/22/3053,
+Lingxiao Ma,Ma,,11,10,https://dblp.org/pid/57/3203,
+Tej Chajed,Chajed,,11,6,https://dblp.org/pid/141/9176,
+Marcos K. Aguilera,Aguilera,"VMware, Palo Alto, CA, USA",11,3,https://dblp.org/pid/10/553,https://orcid.org/0000-0003-3489-2468
+Vijay Chidambaram,Chidambaram,"University of Texas at Austin, Department of Computer Science, TX, USA",11,5,https://dblp.org/pid/07/10563,https://orcid.org/0000-0001-7985-6087
+George Candea,Candea,"Swiss Federal Institute of Technology in Lausanne, Switzerland",11,4,https://dblp.org/pid/c/GeorgeCandea,https://orcid.org/0009-0002-8107-6535
 Christoforos E. Kozyrakis,Kozyrakis,"Stanford University, USA",11,0,https://dblp.org/pid/k/ChristoforosEKozyrakis,https://orcid.org/0000-0002-3154-7530
-Guoqing Harry Xu,Xu,"University of California, Los Angeles, CA, USA",11,0,https://dblp.org/pid/90/8705,https://orcid.org/0000-0003-4737-2146
+Guoqing Harry Xu,Xu,"University of California, Los Angeles, CA, USA",11,3,https://dblp.org/pid/90/8705,https://orcid.org/0000-0003-4737-2146
 David R. Cheriton,Cheriton,"Stanford University, USA",11,0,https://dblp.org/pid/c/DRCheriton,
-Baris Kasikci,Kasikci,,10,0,https://dblp.org/pid/31/11029,https://orcid.org/0000-0001-6122-8998
-Andreas Haeberlen,Haeberlen,,10,0,https://dblp.org/pid/60/4358,https://orcid.org/0000-0002-3271-8354
+Baris Kasikci,Kasikci,,10,4,https://dblp.org/pid/31/11029,https://orcid.org/0000-0001-6122-8998
+Andreas Haeberlen,Haeberlen,,10,2,https://dblp.org/pid/60/4358,https://orcid.org/0000-0002-3271-8354
 Kang Chen,Chen,,10,0,https://dblp.org/pid/91/6670,
-Irene Zhang,Zhang,,10,0,https://dblp.org/pid/68/1122,
-Sylvia Ratnasamy,Ratnasamy,"University of California, Berkeley, USA",10,0,https://dblp.org/pid/68/5579,
-Timothy Roscoe,Roscoe,"ETH Zurich, Switzerland",10,0,https://dblp.org/pid/r/TimothyRoscoe,https://orcid.org/0000-0002-8298-1126
+Irene Zhang,Zhang,,10,4,https://dblp.org/pid/68/1122,
+Sylvia Ratnasamy,Ratnasamy,"University of California, Berkeley, USA",10,2,https://dblp.org/pid/68/5579,
+Timothy Roscoe,Roscoe,"ETH Zurich, Switzerland",10,2,https://dblp.org/pid/r/TimothyRoscoe,https://orcid.org/0000-0002-8298-1126
 Steve D. Gribble,Gribble,"University of Washington, Seattle, Washington, USA",10,0,https://dblp.org/pid/g/StevenDGribble,https://orcid.org/0000-0002-2624-2142
-Ronghui Gu,Gu,"Columbia University, New York, NY, USA",10,0,https://dblp.org/pid/155/8148,
+Ronghui Gu,Gu,"Columbia University, New York, NY, USA",10,7,https://dblp.org/pid/155/8148,
 Gerald J. Popek,Popek,"UCLA, Los Angeles, CA, USA",10,0,https://dblp.org/pid/62/6214,
-Changwoo Min,Min,,9,0,https://dblp.org/pid/19/10203,
-Dan R. K. Ports,Ports,,9,0,https://dblp.org/pid/03/6105,https://orcid.org/0000-0001-6093-5711
-Jilong Xue,Xue,,9,0,https://dblp.org/pid/06/10336,
+Changwoo Min,Min,,9,6,https://dblp.org/pid/19/10203,
+Dan R. K. Ports,Ports,,9,2,https://dblp.org/pid/03/6105,https://orcid.org/0000-0001-6093-5711
+Jilong Xue,Xue,,9,8,https://dblp.org/pid/06/10336,
 David K. Gifford,Gifford,"MIT, Cambridge, USA",9,0,https://dblp.org/pid/g/DavidKGifford,https://orcid.org/0000-0003-1709-4034
-Yang Wang,Wang,"Ohio State University, Columbus, OH, USA",9,0,https://dblp.org/pid/w/YangWang9,https://orcid.org/0000-0002-9721-4923
+Yang Wang,Wang,"Ohio State University, Columbus, OH, USA",9,4,https://dblp.org/pid/w/YangWang9,https://orcid.org/0000-0002-9721-4923
 Madan Musuvathi,Musuvathi,Microsoft Research,9,0,https://dblp.org/pid/95/6578,
 Mahadev Satyanarayanan,Satyanarayanan,"Carnegie Mellon University, Pittsburgh, USA",9,0,https://dblp.org/pid/s/MahadevSatyanarayanan,https://orcid.org/0000-0002-2187-2049
 John K. Ousterhout,Ousterhout,"Stanford University, USA",9,0,https://dblp.org/pid/o/JohnKOusterhout,
 David G. Andersen,Andersen,"Carnegie Mellon University, School of Computer Science, Pittsburgh, PA, USA",9,0,https://dblp.org/pid/a/DavidGAndersen,
-Haryadi S. Gunawi,Gunawi,University of Chicago,9,0,https://dblp.org/pid/84/5664,https://orcid.org/0000-0003-3680-8450
-Willy Zwaenepoel,Zwaenepoel,"University of Sydney, NSW, Australia",9,0,https://dblp.org/pid/z/WZwaenepoel,https://orcid.org/0000-0002-4182-6920
-Ricardo Bianchini,Bianchini,"Microsoft Research, Redmond, WA, USA",9,0,https://dblp.org/pid/85/2722,https://orcid.org/0000-0001-5971-5084
-Rachit Agarwal,Agarwal,"Cornell University, NY, USA",9,0,https://dblp.org/pid/41/5447-1,https://orcid.org/0000-0001-6731-9938
-Asaf Cidon,Cidon,,8,0,https://dblp.org/pid/35/10805,https://orcid.org/0009-0007-4046-2022
-Bryan Parno,Parno,,8,0,https://dblp.org/pid/49/6324,
-Adam Belay,Belay,,8,0,https://dblp.org/pid/14/8279,
-Kirk Rodrigues,Rodrigues,,8,0,https://dblp.org/pid/188/9963,
+Haryadi S. Gunawi,Gunawi,University of Chicago,9,1,https://dblp.org/pid/84/5664,https://orcid.org/0000-0003-3680-8450
+Willy Zwaenepoel,Zwaenepoel,"University of Sydney, NSW, Australia",9,1,https://dblp.org/pid/z/WZwaenepoel,https://orcid.org/0000-0002-4182-6920
+Ricardo Bianchini,Bianchini,"Microsoft Research, Redmond, WA, USA",9,2,https://dblp.org/pid/85/2722,https://orcid.org/0000-0001-5971-5084
+Rachit Agarwal,Agarwal,"Cornell University, NY, USA",9,6,https://dblp.org/pid/41/5447-1,https://orcid.org/0000-0001-6731-9938
+Asaf Cidon,Cidon,,8,8,https://dblp.org/pid/35/10805,https://orcid.org/0009-0007-4046-2022
+Bryan Parno,Parno,,8,4,https://dblp.org/pid/49/6324,
+Adam Belay,Belay,,8,1,https://dblp.org/pid/14/8279,
+Kirk Rodrigues,Rodrigues,,8,4,https://dblp.org/pid/188/9963,
 Michael Kaminsky,Kaminsky,,8,0,https://dblp.org/pid/09/4259,
-K. V. Rashmi,Rashmi,,8,0,https://dblp.org/pid/40/7113,https://orcid.org/0000-0002-2227-7460
-Sebastian Angel,Angel,,8,0,https://dblp.org/pid/132/8480,
-Ramnatthan Alagappan,Alagappan,,8,0,https://dblp.org/pid/154/0847,https://orcid.org/0000-0001-9911-4208
-Srinath T. V. Setty,Setty,,8,0,https://dblp.org/pid/68/8463,
+K. V. Rashmi,Rashmi,,8,3,https://dblp.org/pid/40/7113,https://orcid.org/0000-0002-2227-7460
+Sebastian Angel,Angel,,8,4,https://dblp.org/pid/132/8480,
+Ramnatthan Alagappan,Alagappan,,8,4,https://dblp.org/pid/154/0847,https://orcid.org/0000-0001-9911-4208
+Srinath T. V. Setty,Setty,,8,1,https://dblp.org/pid/68/8463,
 Raluca A. Popa,Popa,"University of California, Berkeley, CA, USA",8,0,https://dblp.org/pid/91/275,https://orcid.org/0000-0001-8899-801X
 Sanjay Ghemawat,Ghemawat,Google Research,8,0,https://dblp.org/pid/g/SGhemawat,
-Antony I. T. Rowstron,Rowstron,Microsoft Research,8,0,https://dblp.org/pid/r/AITRowstron,https://orcid.org/0009-0009-5936-6895
-Zhihao Jia,Jia,,8,0,https://dblp.org/pid/129/3026,
+Antony I. T. Rowstron,Rowstron,Microsoft Research,8,1,https://dblp.org/pid/r/AITRowstron,https://orcid.org/0009-0009-5936-6895
+Zhihao Jia,Jia,,8,6,https://dblp.org/pid/129/3026,
 Emin Gün Sirer,Sirer,"Cornell University, Ithaca, USA",8,0,https://dblp.org/pid/s/EminGunSirer,
-Mosharaf Chowdhury,Chowdhury,"University of Michigan, USA",8,0,https://dblp.org/pid/42/1518,https://orcid.org/0000-0003-0884-6740
+Mosharaf Chowdhury,Chowdhury,"University of Michigan, USA",8,5,https://dblp.org/pid/42/1518,https://orcid.org/0000-0003-0884-6740
 Michael D. Schroeder,Schroeder,Microsoft Research Silicon Valley,8,0,https://dblp.org/pid/s/MichaelDSchroeder,
 David A. Patterson,Patterson,"Google, Mountain View, CA, USA",8,0,https://dblp.org/pid/p/DAPatterson,https://orcid.org/0000-0002-0429-1015
 Butler W. Lampson,Lampson,"Microsoft Research, Cambridge, MA, USA",8,0,https://dblp.org/pid/l/ButlerWLampson,
-Shivaram Venkataraman,Venkataraman,"University of Wisconsin-Madison, WI, USA",8,0,https://dblp.org/pid/65/8569,https://orcid.org/0000-0001-9575-7935
+Shivaram Venkataraman,Venkataraman,"University of Wisconsin-Madison, WI, USA",8,3,https://dblp.org/pid/65/8569,https://orcid.org/0000-0001-9575-7935
 Mendel Rosenblum,Rosenblum,"Stanford University, USA",8,0,https://dblp.org/pid/r/MendelRosenblum,
-Kai Li,Li,"Princeton University, NJ, USA",8,0,https://dblp.org/pid/l/KaiLi1,https://orcid.org/0000-0002-2095-7024
-Yu Luo,Luo,"University of Toronto, Canada",8,0,https://dblp.org/pid/45/6469-6,
+Kai Li,Li,"Princeton University, NJ, USA",8,1,https://dblp.org/pid/l/KaiLi1,https://orcid.org/0000-0002-2095-7024
+Yu Luo,Luo,"University of Toronto, Canada",8,3,https://dblp.org/pid/45/6469-6,
 Allen Clement,Clement,Max Planck Institute for Software Systems,8,0,https://dblp.org/pid/17/597,
-Jacob R. Lorch,Lorch,"Microsoft Research, Redmond, WA, USA",8,0,https://dblp.org/pid/25/3228,https://orcid.org/0000-0002-7269-2769
-Joseph Gonzalez,Gonzalez,"University of California at Berkeley, CA, USA",8,0,https://dblp.org/pid/61/8262,https://orcid.org/0000-0003-2921-956X
+Jacob R. Lorch,Lorch,"Microsoft Research, Redmond, WA, USA",8,2,https://dblp.org/pid/25/3228,https://orcid.org/0000-0002-7269-2769
+Joseph Gonzalez,Gonzalez,"University of California at Berkeley, CA, USA",8,2,https://dblp.org/pid/61/8262,https://orcid.org/0000-0003-2921-956X
 Jay Lepreau,Lepreau,"University of Utah, Salt Lake City, Utah, USA",8,0,https://dblp.org/pid/l/JayLepreau,
-Michael Walfish,Walfish,"New York University, Courant Institute of Mathematical Sciences, NY, USA",8,0,https://dblp.org/pid/00/2879,
+Michael Walfish,Walfish,"New York University, Courant Institute of Mathematical Sciences, NY, USA",8,1,https://dblp.org/pid/00/2879,

--- a/update_hof_from_tsv.py
+++ b/update_hof_from_tsv.py
@@ -56,7 +56,10 @@ def count_recent_publications(rows):
     """Count SOSP/OSDI publications in the last five years for each author."""
     current_year = datetime.date.today().year
     years = range(current_year - 4, current_year + 1)
-    author_name_set = {r["name"].strip() for r in rows}
+    # Use sanitized author names for matching so that names like
+    # "Jane Doe 0001" from DBLP match the sanitized entries
+    # produced when parsing ``hof-raw.tsv``.
+    author_name_set = {sanitize_name(r["name"].strip()) for r in rows}
     counts = defaultdict(int)
 
     for venue in VENUES:
@@ -77,6 +80,10 @@ def count_recent_publications(rows):
                 if isinstance(authors, dict):
                     authors = [authors]
                 for author in authors:
+                    # DBLP often appends numerical disambiguators to
+                    # author names (e.g., "Jane Doe 0001").  We strip
+                    # those here so the comparison with our sanitized
+                    # names succeeds.
                     name = sanitize_name(author.get("text", "").strip())
                     if name in author_name_set:
                         counts[name] += 1
@@ -93,8 +100,9 @@ def main() -> None:
     rows = parse_rows(INPUT_FILE)
     recent_counts = count_recent_publications(rows)
     for row in rows:
-        row["last"] = row["name"].split()[-1] if row["name"] else ""
-        row["lastfive"] = recent_counts.get(row["name"], 0)
+        sanitized = sanitize_name(row["name"])
+        row["last"] = sanitized.split()[-1] if sanitized else ""
+        row["lastfive"] = recent_counts.get(sanitized, 0)
 
     rows.sort(key=lambda r: r["freq"], reverse=True)
 


### PR DESCRIPTION
## Summary
- Ensure Hall of Fame "Last 5 Years" counts use sanitized author names
- Restore non-zero `lastfive` values in `_data/hof.csv`

## Testing
- `python update_hof_from_tsv.py` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile update_hof_from_tsv.py`


------
https://chatgpt.com/codex/tasks/task_e_689b6f3a4bb083258a8a1e6b68c66ff0