### PR TITLE
Fix extra spacing above publication headings

### DIFF
--- a/_pages/full-publications.md
+++ b/_pages/full-publications.md
@@ -18,35 +18,43 @@ years: [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
 {% capture preprints %}{% bibliography --template bibtemplate --query @unpublished %}{% endcapture %}
 {% assign preprints = preprints | strip %}
 {% if preprints contains 'publication-entry' %}
+
 <details class="jumbotron">
 <summary><h3 style="font-size: 1.2rem; font-weight: bold; margin: 0;">Preprints</h3></summary>
 {{ preprints }}
 </details>
+
 {% endif %}
 
 {% capture conf %}{% bibliography --template bibtemplate --query @inproceedings[group != workshop] %}{% endcapture %}
 {% assign conf = conf | strip %}
 {% unless conf == "" %}
+
 <details class="jumbotron">
 <summary><h3 style="font-size: 1.2rem; font-weight: bold; margin: 0;">Refereed conference proceedings</h3></summary>
 {{ conf }}
 </details>
+
 {% endunless %}
 
 {% capture journal %}{% bibliography --template bibtemplate --query @article %}{% endcapture %}
 {% assign journal = journal | strip %}
 {% unless journal == "" %}
+
 <details class="jumbotron">
 <summary><h3 style="font-size: 1.2rem; font-weight: bold; margin: 0;">Refereed journal articles</h3></summary>
 {{ journal }}
 </details>
+
 {% endunless %}
 
 {% capture workshop %}{% bibliography --template bibtemplate --query @*[group = workshop] %}{% endcapture %}
 {% assign workshop = workshop | strip %}
 {% unless workshop == "" %}
+
 <details class="jumbotron">
 <summary><h3 style="font-size: 1.2rem; font-weight: bold; margin: 0;">Workshop papers</h3></summary>
 {{ workshop }}
 </details>
+
 {% endunless %}


### PR DESCRIPTION
## Summary
- ensure `<details>` sections in Publications page are separated by blank lines to avoid stray `<p>` elements on deployment

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689bce2059888325a9503b8d85f1372b