### PR TITLE
Break long service lines after multi-word organization names

### DIFF
--- a/_pages/service.md
+++ b/_pages/service.md
@@ -44,8 +44,7 @@ permalink: /service/
           </span>
           {%- unless forloop.last -%}
             ,&nbsp;
-            {% assign words = org_name | split: ' ' %}
-            {% if words.size > 1 %}<br>{% endif %}
+            {% if org_name contains ' ' %}<br>{% endif %}
           {%- endunless -%}
         {% endfor %}
       </div>
@@ -71,8 +70,7 @@ permalink: /service/
           </span>
           {%- unless forloop.last -%}
             ,&nbsp;
-            {% assign words = org_name | split: ' ' %}
-            {% if words.size > 1 %}<br>{% endif %}
+            {% if org_name contains ' ' %}<br>{% endif %}
           {%- endunless -%}
         {% endfor %}
       </div>
@@ -102,8 +100,7 @@ permalink: /service/
             </span>
             {%- unless forloop.last -%}
               ,&nbsp;
-              {% assign words = org_name | split: ' ' %}
-              {% if words.size > 1 %}<br>{% endif %}
+              {% if org_name contains ' ' %}<br>{% endif %}
             {%- endunless -%}
           {% endfor %}
         </div>

--- a/_pages/service.md
+++ b/_pages/service.md
@@ -17,6 +17,9 @@ permalink: /service/
   align-items: flex-start;
   margin-bottom: 1rem;
 }
+.service-orgs {
+  margin-left: 5px;
+}
 .service-number {
   padding-right: 10px;
 }
@@ -36,17 +39,20 @@ permalink: /service/
       {% assign role = role_data[0] %}
       {% assign services = role_data[1] %}
       <div class="service-item" style="margin-left: 20px;">
-        <strong>{{ role }}:</strong>&nbsp;{% for service in services %}
-          {% assign year = service['Start Date'] | date: '%Y' %}
-          {% assign org_name = service.Organization | remove: year | strip %}
-          <span style="white-space: nowrap;">
-          {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}
-          </span>
-          {%- unless forloop.last -%}
-            ,&nbsp;
-            {% if org_name contains ' ' %}<br>{% endif %}
-          {%- endunless -%}
-        {% endfor %}
+        <strong>{{ role }}:</strong>
+        <div class="service-orgs">
+          {% for service in services %}
+            {% assign year = service['Start Date'] | date: '%Y' %}
+            {% assign org_name = service.Organization | remove: year | strip %}
+            <span style="white-space: nowrap;">
+            {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}
+            </span>
+            {%- unless forloop.last -%}
+              ,&nbsp;
+              {% if org_name contains ' ' %}<br>{% endif %}
+            {%- endunless -%}
+          {% endfor %}
+        </div>
       </div>
     {% endfor %}
   </div>
@@ -62,17 +68,20 @@ permalink: /service/
       {% assign role = role_data[0] %}
       {% assign services = role_data[1] %}
       <div class="service-item" style="margin-left: 20px;">
-        <strong>{{ role }}:</strong>&nbsp;{% for service in services %}
-          {% assign year = service['Start Date'] | date: '%Y' %}
-          {% assign org_name = service.Organization | remove: year | strip %}
-          <span style="white-space: nowrap;">
-          {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}
-          </span>
-          {%- unless forloop.last -%}
-            ,&nbsp;
-            {% if org_name contains ' ' %}<br>{% endif %}
-          {%- endunless -%}
-        {% endfor %}
+        <strong>{{ role }}:</strong>
+        <div class="service-orgs">
+          {% for service in services %}
+            {% assign year = service['Start Date'] | date: '%Y' %}
+            {% assign org_name = service.Organization | remove: year | strip %}
+            <span style="white-space: nowrap;">
+            {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}
+            </span>
+            {%- unless forloop.last -%}
+              ,&nbsp;
+              {% if org_name contains ' ' %}<br>{% endif %}
+            {%- endunless -%}
+          {% endfor %}
+        </div>
       </div>
     {% endfor %}
   </div>
@@ -92,17 +101,20 @@ permalink: /service/
         {% assign role = role_data[0] %}
         {% assign services = role_data[1] %}
         <div class="service-item" style="margin-left: 20px;">
-          <strong>{{ role }}:</strong>&nbsp;{% for service in services %}
-            {% assign year_to_remove = service['Start Date'] | date: '%Y' %}
-            {% assign org_name = service.Organization | remove: year_to_remove | strip %}
-            <span style="white-space: nowrap;">
-            {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}
-            </span>
-            {%- unless forloop.last -%}
-              ,&nbsp;
-              {% if org_name contains ' ' %}<br>{% endif %}
-            {%- endunless -%}
-          {% endfor %}
+          <strong>{{ role }}:</strong>
+          <div class="service-orgs">
+            {% for service in services %}
+              {% assign year_to_remove = service['Start Date'] | date: '%Y' %}
+              {% assign org_name = service.Organization | remove: year_to_remove | strip %}
+              <span style="white-space: nowrap;">
+              {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}
+              </span>
+              {%- unless forloop.last -%}
+                ,&nbsp;
+                {% if org_name contains ' ' %}<br>{% endif %}
+              {%- endunless -%}
+            {% endfor %}
+          </div>
         </div>
       {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Summary
- ensure service page breaks long role lines after multi-word organization names, keeping short names on same line

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689e2a91b5a8832598571f42d0c15783