### PR TITLE
Handle cross-year service tasks and show all upcoming service

### DIFF
--- a/_pages/service.md
+++ b/_pages/service.md
@@ -62,7 +62,7 @@ permalink: /service/
 <!-- Upcoming Service -->
 {% if site.data.upcoming_service.size > 0 %}
 <details class="jumbotron" open>
-  <summary style="font-size: 1.2rem; font-weight: 600;">Upcoming Service (in next 3 months)</summary>
+  <summary style="font-size: 1.2rem; font-weight: 600;">Upcoming Service</summary>
   <div class="year-list">
     {% for role_data in site.data.upcoming_service %}
       {% assign role = role_data[0] %}
@@ -104,7 +104,7 @@ permalink: /service/
           <strong>{{ role }}:</strong>
           <div class="service-orgs">
             {% for service in services %}
-              {% assign year_to_remove = service['Start Date'] | date: '%Y' %}
+              {% assign year_to_remove = year %}
               {% assign org_name = service.Organization | remove: year_to_remove | strip %}
               <span style="white-space: nowrap;">
               {% if service.Website %}<a href="{{ service.Website }}">{{ org_name }}</a>{% else %}{{ org_name }}{% endif %}

--- a/_plugins/service_generator.rb
+++ b/_plugins/service_generator.rb
@@ -15,7 +15,6 @@ module Jekyll
       all_service = {}
 
       today = Date.today
-      three_months_later = Date.today >> 3
 
       service_data.each do |service|
         start_date_str = service['Start Date']
@@ -32,13 +31,17 @@ module Jekyll
         end
 
         # Upcoming Service
-        if start_date > today && start_date <= three_months_later
+        if start_date > today
           upcoming_service[role] ||= []
           upcoming_service[role] << service
         end
 
         # All Service
-        year = start_date.year
+        if end_date && end_date.year > start_date.year
+          year = end_date.year
+        else
+          year = start_date.year
+        end
         all_service[year] ||= {}
         all_service[year][role] ||= []
         all_service[year][role] << service


### PR DESCRIPTION
## Summary
- Display service entries under the later year if start and end cross years
- Show all upcoming service and clean up Upcoming Service header
- Avoid repeating year in organization names for archived service

## Testing
- `bundle install` *(fails: client error, installation interrupted)*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689e34ca6d9483258d5ec805eb97824c